### PR TITLE
Experiment with slick DSL for simpler queries

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -50,49 +50,49 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     config.get[Int]("ot.elasticsearch.port"))
   val esQ = HttpClient(esUri)
 
-//  def buildPheWASTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
-//  Future[Entities.PheWASTable] = {
-//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-//    val variant = Variant(variantID)
-//
-//    variant match {
-//      case Right(v) =>
-//        val segment = toSumStatsSegment(v.position.position)
-//        val tableName = gwasSumStatsTName format v.position.chrId
-//        val query =
-//          sql"""
-//               |select
-//               | study_id,
-//               | pval,
-//               | beta,
-//               | se,
-//               | eaf,
-//               | maf,
-//               | n_samples_variant_level,
-//               | n_samples_study_level,
-//               | n_cases_study_level,
-//               | n_cases_variant_level,
-//               | if(is_cc,exp(beta),NULL) as odds_ratio,
-//               | chip,
-//               | info
-//               |from #$tableName
-//               |prewhere chrom = ${v.position.chrId} and
-//               |  pos_b37 = ${v.position.position} and
-//               |  segment = $segment and
-//               |  variant_id_b37 = ${v.id}
-//               |#$limitClause
-//         """.stripMargin.as[VariantPheWAS]
-//
-//        dbSS.run(query.asTry).map {
-//          case Success(traitVector) => PheWASTable(traitVector)
-//          case Failure(ex) =>
-//            logger.error(ex.getMessage)
-//            PheWASTable(associations = Vector.empty)
-//        }
-//
-//      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
-//    }
-//  }
+  def buildPheWASTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
+  Future[Entities.PheWASTable] = {
+    val limitClause = parsePaginationTokens(pageIndex, pageSize)
+    val variant = Variant(variantID)
+
+    variant match {
+      case Right(v) =>
+        val segment = toSumStatsSegment(v.position.position)
+        val tableName = gwasSumStatsTName format v.position.chrId
+        val query =
+          sql"""
+               |select
+               | study_id,
+               | pval,
+               | beta,
+               | se,
+               | eaf,
+               | maf,
+               | n_samples_variant_level,
+               | n_samples_study_level,
+               | n_cases_study_level,
+               | n_cases_variant_level,
+               | if(is_cc,exp(beta),NULL) as odds_ratio,
+               | chip,
+               | info
+               |from #$tableName
+               |prewhere chrom = ${v.position.chrId} and
+               |  pos_b37 = ${v.position.position} and
+               |  segment = $segment and
+               |  variant_id_b37 = ${v.id}
+               |#$limitClause
+         """.stripMargin.as[VariantPheWAS]
+
+        dbSS.run(query.asTry).map {
+          case Success(traitVector) => PheWASTable(traitVector)
+          case Failure(ex) =>
+            logger.error(ex.getMessage)
+            PheWASTable(associations = Vector.empty)
+        }
+
+      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
+    }
+  }
 
   def getG2VSchema: Future[Entities.G2VSchema] = {
     def toSeqStruct(elems: Map[String, Map[String, String]]) = {
@@ -126,60 +126,60 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     }
   }
 
-//  def getSearchResultSet(qString: String, pageIndex: Option[Int], pageSize: Option[Int]):
-//  Future[Entities.SearchResultSet] = {
-//    val limitClause = parsePaginationTokensForES(pageIndex, pageSize)
-//    val stoken = qString.toLowerCase
-//    // val stoken = qString
-//    val cleanedTokens = stoken.replaceAll("-", " ")
-//
-//    if (stoken.length > 0) {
-//      esQ.execute {
-//          search("studies") query boolQuery.should(matchQuery("study_id", stoken),
-//            matchQuery("pmid", stoken),
-//            multiMatchQuery(cleanedTokens)
-//              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
-//              .lenient(true)
-//              .slop(10)
-//              .prefixLength(2)
-//              .maxExpansions(50)
-//              .operator("OR")
-//              .analyzer(WhitespaceAnalyzer)
-//              .fields(Map("trait_reported" -> 1.5F,
-//                "pub_author" -> 1.2F,
-//                "_all" -> 1.0F)),
-//            simpleStringQuery(cleanedTokens)
-//              .defaultOperator("AND")
-//            ) start limitClause._1 limit limitClause._2 sortByFieldDesc "n_initial"
-//      }.zip {
-//        esQ.execute {
-//          search("variant_*") query boolQuery.should(matchQuery("variant_id", stoken),
-//            matchQuery("rs_id", stoken)) start limitClause._1 limit limitClause._2
-//        }
-//      }.zip {
-//        esQ.execute {
-//          search("genes") query boolQuery.should(matchQuery("gene_id", stoken),
-//            matchQuery("gene_name", stoken),
-//            multiMatchQuery(cleanedTokens)
-//              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
-//              .lenient(true)
-//              .slop(10)
-//              .prefixLength(2)
-//              .maxExpansions(50)
-//              .operator("OR")
-//              .analyzer(WhitespaceAnalyzer)
-//              .fields("gene_name")) start limitClause._1 limit limitClause._2
-//        }
-//      }.map{
-//        case ((studiesRS, variantsRS), genesRS) =>
-//          SearchResultSet(genesRS.totalHits, genesRS.to[FRM.Gene],
-//            variantsRS.totalHits, variantsRS.to[VariantSearchResult],
-//            studiesRS.totalHits, studiesRS.to[FRM.Study])
-//      }
-//    } else {
-//      Future.failed(InputParameterCheckError(Vector(SearchStringViolation())))
-//    }
-//  }
+  def getSearchResultSet(qString: String, pageIndex: Option[Int], pageSize: Option[Int]):
+  Future[Entities.SearchResultSet] = {
+    val limitClause = parsePaginationTokensForES(pageIndex, pageSize)
+    val stoken = qString.toLowerCase
+    // val stoken = qString
+    val cleanedTokens = stoken.replaceAll("-", " ")
+
+    if (stoken.length > 0) {
+      esQ.execute {
+          search("studies") query boolQuery.should(matchQuery("study_id", stoken),
+            matchQuery("pmid", stoken),
+            multiMatchQuery(cleanedTokens)
+              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
+              .lenient(true)
+              .slop(10)
+              .prefixLength(2)
+              .maxExpansions(50)
+              .operator("OR")
+              .analyzer(WhitespaceAnalyzer)
+              .fields(Map("trait_reported" -> 1.5F,
+                "pub_author" -> 1.2F,
+                "_all" -> 1.0F)),
+            simpleStringQuery(cleanedTokens)
+              .defaultOperator("AND")
+            ) start limitClause._1 limit limitClause._2 sortByFieldDesc "n_initial"
+      }.zip {
+        esQ.execute {
+          search("variant_*") query boolQuery.should(matchQuery("variant_id", stoken),
+            matchQuery("rs_id", stoken)) start limitClause._1 limit limitClause._2
+        }
+      }.zip {
+        esQ.execute {
+          search("genes") query boolQuery.should(matchQuery("gene_id", stoken),
+            matchQuery("gene_name", stoken),
+            multiMatchQuery(cleanedTokens)
+              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
+              .lenient(true)
+              .slop(10)
+              .prefixLength(2)
+              .maxExpansions(50)
+              .operator("OR")
+              .analyzer(WhitespaceAnalyzer)
+              .fields("gene_name")) start limitClause._1 limit limitClause._2
+        }
+      }.map{
+        case ((studiesRS, variantsRS), genesRS) =>
+          SearchResultSet(genesRS.totalHits, genesRS.to[FRM.Gene],
+            variantsRS.totalHits, variantsRS.to[VariantSearchResult],
+            studiesRS.totalHits, studiesRS.to[FRM.Study])
+      }
+    } else {
+      Future.failed(InputParameterCheckError(Vector(SearchStringViolation())))
+    }
+  }
 
   /** get top Functions.defaultTopOverlapStudiesSize studies sorted desc by
     * the number of overlapped loci
@@ -187,99 +187,99 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     * @param stid given a study ID
     * @return a Entities.OverlappedLociStudy which could contain empty list of ovelapped studies
     */
-//  def getTopOverlappedStudies(stid: String, pageIndex: Option[Int] = Some(0), pageSize: Option[Int] = Some(defaultTopOverlapStudiesSize)):
-//  Future[Entities.OverlappedLociStudy] = {
-//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-//
-//    val topOverlappedsSQL = sql"""
-//                          |SELECT
-//                          |  study_id_b,
-//                          |  uniq(index_variant_id_a) AS num_overlap_loci
-//                          |FROM #$studiesOverlapTName
-//                          |PREWHERE (study_id_a = $stid) and
-//                          |  set_type = 'combined'
-//                          |GROUP BY
-//                          |  study_id_a,
-//                          |  study_id_b
-//                          |ORDER BY num_overlap_loci desc
-//                          |#$limitClause
-//      """.stripMargin.as[(String, Int)]
-//
-//    db.run(topOverlappedsSQL.asTry).map {
-//      case Success(v) =>
-//        if (v.nonEmpty) {
-//          OverlappedLociStudy(stid, v.map(t => OverlapRow(t._1, t._2)))
-//        } else {
-//          OverlappedLociStudy(stid, Vector.empty)
-//        }
-//      case Failure(ex) =>
-//        logger.error(ex.getMessage)
-//        OverlappedLociStudy(stid, Vector.empty)
-//    }
-//  }
+  def getTopOverlappedStudies(stid: String, pageIndex: Option[Int] = Some(0), pageSize: Option[Int] = Some(defaultTopOverlapStudiesSize)):
+  Future[Entities.OverlappedLociStudy] = {
+    val limitClause = parsePaginationTokens(pageIndex, pageSize)
 
-//  def getOverlapVariantsIntersectionForStudies(stid: String, stids: Seq[String]): Future[Vector[String]] = {
-//    val stidListString = stids.map("'" + _ + "'").mkString(",")
-//    val numStids = if (stids.nonEmpty) stids.length else 0
-//    val overlapSQL = sql"""
-//                          |SELECT index_variant_id_a
-//                          |FROM
-//                          |(
-//                          |    SELECT
-//                          |        index_variant_id_a,
-//                          |        uniq(study_id_b) AS num_studies
-//                          |    FROM #$studiesOverlapTName
-//                          |    PREWHERE (study_id_a = $stid) AND
-//                          |        (study_id_b IN (#${stidListString})) AND
-//                          |        (set_type = 'combined')
-//                          |    GROUP BY index_variant_id_a
-//                          |    HAVING num_studies = ${numStids}
-//                          |)
-//      """.stripMargin.as[String]
-//
-//    db.run(overlapSQL.asTry).map {
-//      case Success(v) => v
-//      case Failure(ex) =>
-//        logger.error(ex.getMessage)
-//        Vector.empty
-//    }
-//  }
+    val topOverlappedsSQL = sql"""
+                          |SELECT
+                          |  study_id_b,
+                          |  uniq(index_variant_id_a) AS num_overlap_loci
+                          |FROM #$studiesOverlapTName
+                          |PREWHERE (study_id_a = $stid) and
+                          |  set_type = 'combined'
+                          |GROUP BY
+                          |  study_id_a,
+                          |  study_id_b
+                          |ORDER BY num_overlap_loci desc
+                          |#$limitClause
+      """.stripMargin.as[(String, Int)]
 
-//  def getOverlapVariantsForStudies(stid: String, stids: Seq[String]): Future[Vector[Entities.OverlappedVariantsStudy]] = {
-//    val stidListString = stids.map("'" + _ + "'").mkString(",")
-//    val overlapSQL = sql"""
-//                          |SELECT
-//                          |  study_id_b,
-//                          |  index_variant_id_a,
-//                          |  index_variant_id_b,
-//                          |  any(overlap_AB) AS overlap_AB,
-//                          |  any(distinct_A) AS distinct_A,
-//                          |  any(distinct_B) AS distinct_B
-//                          |FROM #$studiesOverlapTName
-//                          |PREWHERE (study_id_a = $stid) AND
-//                          |  (study_id_b IN (#${stidListString})) AND
-//                          |  (set_type = 'combined')
-//                          |GROUP BY
-//                          |  study_id_a,
-//                          |  study_id_b,
-//                          |  index_variant_id_a,
-//                          |  index_variant_id_b
-//      """.stripMargin.as[(String, String, String, Int, Int, Int)]
-//
-//    db.run(overlapSQL.asTry).map {
-//      case Success(v) =>
-//        if (v.nonEmpty) {
-//          v.view.groupBy(_._1).map(pair =>
-//            OverlappedVariantsStudy(pair._1,
-//              pair._2.map(t => OverlappedVariant(t._2, t._3, t._4, t._5, t._6)))).toVector
-//        } else {
-//          Vector.empty
-//        }
-//      case Failure(ex) =>
-//        logger.error(ex.getMessage)
-//        Vector.empty
-//    }
-//  }
+    db.run(topOverlappedsSQL.asTry).map {
+      case Success(v) =>
+        if (v.nonEmpty) {
+          OverlappedLociStudy(stid, v.map(t => OverlapRow(t._1, t._2)))
+        } else {
+          OverlappedLociStudy(stid, Vector.empty)
+        }
+      case Failure(ex) =>
+        logger.error(ex.getMessage)
+        OverlappedLociStudy(stid, Vector.empty)
+    }
+  }
+
+  def getOverlapVariantsIntersectionForStudies(stid: String, stids: Seq[String]): Future[Vector[String]] = {
+    val stidListString = stids.map("'" + _ + "'").mkString(",")
+    val numStids = if (stids.nonEmpty) stids.length else 0
+    val overlapSQL = sql"""
+                          |SELECT index_variant_id_a
+                          |FROM
+                          |(
+                          |    SELECT
+                          |        index_variant_id_a,
+                          |        uniq(study_id_b) AS num_studies
+                          |    FROM #$studiesOverlapTName
+                          |    PREWHERE (study_id_a = $stid) AND
+                          |        (study_id_b IN (#${stidListString})) AND
+                          |        (set_type = 'combined')
+                          |    GROUP BY index_variant_id_a
+                          |    HAVING num_studies = ${numStids}
+                          |)
+      """.stripMargin.as[String]
+
+    db.run(overlapSQL.asTry).map {
+      case Success(v) => v
+      case Failure(ex) =>
+        logger.error(ex.getMessage)
+        Vector.empty
+    }
+  }
+
+  def getOverlapVariantsForStudies(stid: String, stids: Seq[String]): Future[Vector[Entities.OverlappedVariantsStudy]] = {
+    val stidListString = stids.map("'" + _ + "'").mkString(",")
+    val overlapSQL = sql"""
+                          |SELECT
+                          |  study_id_b,
+                          |  index_variant_id_a,
+                          |  index_variant_id_b,
+                          |  any(overlap_AB) AS overlap_AB,
+                          |  any(distinct_A) AS distinct_A,
+                          |  any(distinct_B) AS distinct_B
+                          |FROM #$studiesOverlapTName
+                          |PREWHERE (study_id_a = $stid) AND
+                          |  (study_id_b IN (#${stidListString})) AND
+                          |  (set_type = 'combined')
+                          |GROUP BY
+                          |  study_id_a,
+                          |  study_id_b,
+                          |  index_variant_id_a,
+                          |  index_variant_id_b
+      """.stripMargin.as[(String, String, String, Int, Int, Int)]
+
+    db.run(overlapSQL.asTry).map {
+      case Success(v) =>
+        if (v.nonEmpty) {
+          v.view.groupBy(_._1).map(pair =>
+            OverlappedVariantsStudy(pair._1,
+              pair._2.map(t => OverlappedVariant(t._2, t._3, t._4, t._5, t._6)))).toVector
+        } else {
+          Vector.empty
+        }
+      case Failure(ex) =>
+        logger.error(ex.getMessage)
+        Vector.empty
+    }
+  }
 
   def getStudiesForGene(geneId: String): Future[Vector[String]] = {
     val studiesSQL = sql"""
@@ -353,58 +353,57 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     }
   }
 
-//  case class ManhattanTable(studyId: String, associations: Vector[ManhattanAssociation])
-//  def buildManhattanTable(studyId: String, pageIndex: Option[Int], pageSize: Option[Int]):
-//  Future[Entities.ManhattanTable] = {
-//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-//
-//    val idxVariants = sql"""
-//      |SELECT
-//      |    index_variant_id,
-//      |    pval,
-//      |    credibleSetSize,
-//      |    ldSetSize,
-//      |    uniq_variants,
-//      |    top_genes_ids,
-//      |    top_genes_scores
-//      |FROM
-//      |(
-//      |    SELECT
-//      |        index_variant_id,
-//      |        any(pval) AS pval,
-//      |        uniqIf(variant_id, posterior_prob > 0) AS credibleSetSize,
-//      |        uniqIf(variant_id, r2 > 0) AS ldSetSize,
-//      |        uniq(variant_id) AS uniq_variants
-//      |    FROM #$v2dByStTName
-//      |    PREWHERE stid = $studyId
-//      |    GROUP BY index_variant_id
-//      |)
-//      |ALL LEFT OUTER JOIN
-//      |(
-//      |    SELECT
-//      |        variant_id AS index_variant_id,
-//      |        groupArray(gene_id) AS top_genes_ids,
-//      |        groupArray(overall_score) AS top_genes_scores
-//      |    FROM ot.d2v2g_score_by_overall
-//      |    PREWHERE (variant_id = index_variant_id) AND (overall_score > 0.)
-//      |    GROUP BY variant_id
-//      |) USING (index_variant_id)
-//      |#$limitClause
-//      """.stripMargin.as[V2DByStudy]
-//
-//    // map to proper manhattan association with needed fields
-//    db.run(idxVariants.asTry).map {
-//      case Success(v) => ManhattanTable(studyId,
-//        v.map(el => {
-//          ManhattanAssociation(el.index_variant_id, el.pval, el.topGenes,
-//            el.credibleSetSize, el.ldSetSize, el.totalSetSize)
-//        })
-//      )
-//      case Failure(ex) =>
-//        logger.error(ex.getMessage)
-//        ManhattanTable(studyId, associations = Vector.empty)
-//    }
-//  }
+  def buildManhattanTable(studyId: String, pageIndex: Option[Int], pageSize: Option[Int]):
+  Future[Entities.ManhattanTable] = {
+    val limitClause = parsePaginationTokens(pageIndex, pageSize)
+
+    val idxVariants = sql"""
+      |SELECT
+      |    index_variant_id,
+      |    pval,
+      |    credibleSetSize,
+      |    ldSetSize,
+      |    uniq_variants,
+      |    top_genes_ids,
+      |    top_genes_scores
+      |FROM
+      |(
+      |    SELECT
+      |        index_variant_id,
+      |        any(pval) AS pval,
+      |        uniqIf(variant_id, posterior_prob > 0) AS credibleSetSize,
+      |        uniqIf(variant_id, r2 > 0) AS ldSetSize,
+      |        uniq(variant_id) AS uniq_variants
+      |    FROM #$v2dByStTName
+      |    PREWHERE stid = $studyId
+      |    GROUP BY index_variant_id
+      |)
+      |ALL LEFT OUTER JOIN
+      |(
+      |    SELECT
+      |        variant_id AS index_variant_id,
+      |        groupArray(gene_id) AS top_genes_ids,
+      |        groupArray(overall_score) AS top_genes_scores
+      |    FROM ot.d2v2g_score_by_overall
+      |    PREWHERE (variant_id = index_variant_id) AND (overall_score > 0.)
+      |    GROUP BY variant_id
+      |) USING (index_variant_id)
+      |#$limitClause
+      """.stripMargin.as[V2DByStudy]
+
+    // map to proper manhattan association with needed fields
+    db.run(idxVariants.asTry).map {
+      case Success(v) => ManhattanTable(studyId,
+        v.map(el => {
+          ManhattanAssociation(el.index_variant_id, el.pval, el.topGenes,
+            el.credibleSetSize, el.ldSetSize, el.totalSetSize)
+        })
+      )
+      case Failure(ex) =>
+        logger.error(ex.getMessage)
+        ManhattanTable(studyId, associations = Vector.empty)
+    }
+  }
 
   def buildIndexVariantAssocTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
   Future[IndexVariantTable] = {
@@ -491,136 +490,93 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
       case Left(violation) =>
         Future.failed(InputParameterCheckError(Vector(violation)))
     }
-
-
-
-//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-//    val variant = Variant(variantID)
-//
-//    variant match {
-//      case Right(v) =>
-//        val assocs = sql"""
-//                          |select
-//                          | index_variant_id,
-//                          | index_rs_id,
-//                          | stid,
-//                          | pval,
-//                          | ifNull(n_initial,0) + ifNull(n_replication,0),
-//                          | ifNull(n_cases, 0),
-//                          | r2,
-//                          | afr_1000g_prop,
-//                          | amr_1000g_prop,
-//                          | eas_1000g_prop,
-//                          | eur_1000g_prop,
-//                          | sas_1000g_prop,
-//                          | log10_abf,
-//                          | posterior_prob
-//                          |from #$v2dByChrPosTName
-//                          |prewhere
-//                          |  chr_id = ${v.position.chrId} and
-//                          |  position = ${v.position.position} and
-//                          |  ref_allele = ${v.refAllele} and
-//                          |  alt_allele = ${v.altAllele}
-//                          |#$limitClause
-//          """.stripMargin.as[TagVariantAssociation]
-//
-//        // map to proper manhattan association with needed fields
-//        db.run(assocs.asTry).map {
-//          case Success(r) => Entities.TagVariantTable(r)
-//          case Failure(ex) =>
-//            logger.error(ex.getMessage)
-//            Entities.TagVariantTable(associations = Vector.empty)
-//        }
-//      case Left(violation) =>
-//        Future.failed(InputParameterCheckError(Vector(violation)))
-//    }
   }
 
-//  def buildGecko(chromosome: String, posStart: Long, posEnd: Long): Future[Option[Entities.Gecko]] = {
-//    (parseChromosome(chromosome), parseRegion(posStart, posEnd)) match {
-//      case (Right(chr), Right((start, end))) =>
-//        val inRegion = Region(chr, start, end)
-//        if (denseRegionChecker.matchRegion(inRegion)) {
-//          Future.failed(InputParameterCheckError(Vector(RegionViolation(inRegion))))
-//        } else {
-//            val geneIdsInLoci = sql"""
-//                                     |SELECT
-//                                     | gene_id
-//                                     |FROM ot.gene
-//                                     |WHERE
-//                                     | chr = $chr and (
-//                                     | (start >= $start and start <= $end) or
-//                                     | (end >= $start and end <= $end))
-//                """.stripMargin.as[String]
-//
-//            val assocs = sql"""
-//                              |SELECT
-//                              |  variant_id,
-//                              |  rs_id,
-//                              |  index_variant_id,
-//                              |  index_variant_rsid,
-//                              |  gene_id,
-//                              |  stid,
-//                              |  r2,
-//                              |  posterior_prob,
-//                              |  pval,
-//                              |  overall_score
-//                              |FROM (
-//                              | SELECT
-//                              |  stid,
-//                              |  variant_id,
-//                              |  any(rs_id) as rs_id,
-//                              |  index_variant_id,
-//                              |  any(index_variant_rsid) as index_variant_rsid,
-//                              |  gene_id,
-//                              |  any(r2) as r2,
-//                              |  any(posterior_prob) as posterior_prob,
-//                              |  any(pval) as pval
-//                              | FROM #$d2v2gTName
-//                              | PREWHERE
-//                              |   chr_id = $chr and (
-//                              |   (position >= $start and position <= $end) or
-//                              |   (index_position >= $start and index_position <= $end) or
-//                              |   (dictGetUInt32('gene','start',tuple(gene_id)) >= $start and
-//                              |     dictGetUInt32('gene','start',tuple(gene_id)) <= $end) or
-//                              |   (dictGetUInt32('gene','end',tuple(gene_id)) >= $start and
-//                              |     dictGetUInt32('gene','end',tuple(gene_id)) <= $end))
-//                              | group by stid, index_variant_id, variant_id, gene_id
-//                              |) all inner join (
-//                              | SELECT
-//                              |   variant_id,
-//                              |   gene_id,
-//                              |   overall_score
-//                              | FROM #$d2v2gOScoresTName
-//                              | PREWHERE chr_id = $chr and
-//                              | overall_score > 0.
-//                              |) USING (variant_id, gene_id)
-//                """.stripMargin
-//              .as[GeckoLine]
-//
-//              db.run(
-//                geneIdsInLoci.asTry zip assocs.asTry).map {
-//                case (Success(geneIds), Success(assocs
-//                )) => Entities.
-//                  Gecko(assocs.view, geneIds.toSet)
-//                case (Success(geneIds), Failure(
-//                asscsEx)) =>
-//                  logger.
-//                    error(asscsEx.getMessage)
-//                  Entities.Gecko(Seq.
-//                    empty, geneIds.toSet)
-//                case (_, _) =>
-//                  logger.error("Something really wrong happened while getting geneIds from gene " +
-//                    "dictionary and also from d2v2g table")
-//                  Entities.Gecko(Seq.empty, Set.empty)
-//              }
-//            }
-//
-//      case (chrEither, rangeEither) =>
-//        Future.failed(InputParameterCheckError(
-//          Vector(chrEither, rangeEither).filter(_.isLeft).map(_.left.get).asInstanceOf[Vector[Violation]]))
-//    }
-//  }
+  def buildGecko(chromosome: String, posStart: Long, posEnd: Long): Future[Option[Entities.Gecko]] = {
+    (parseChromosome(chromosome), parseRegion(posStart, posEnd)) match {
+      case (Right(chr), Right((start, end))) =>
+        val inRegion = Region(chr, start, end)
+        if (denseRegionChecker.matchRegion(inRegion)) {
+          Future.failed(InputParameterCheckError(Vector(RegionViolation(inRegion))))
+        } else {
+            val geneIdsInLoci = sql"""
+                                     |SELECT
+                                     | gene_id
+                                     |FROM ot.gene
+                                     |WHERE
+                                     | chr = $chr and (
+                                     | (start >= $start and start <= $end) or
+                                     | (end >= $start and end <= $end))
+                """.stripMargin.as[String]
+
+            val assocs = sql"""
+                              |SELECT
+                              |  variant_id,
+                              |  rs_id,
+                              |  index_variant_id,
+                              |  index_variant_rsid,
+                              |  gene_id,
+                              |  stid,
+                              |  r2,
+                              |  posterior_prob,
+                              |  pval,
+                              |  overall_score
+                              |FROM (
+                              | SELECT
+                              |  stid,
+                              |  variant_id,
+                              |  any(rs_id) as rs_id,
+                              |  index_variant_id,
+                              |  any(index_variant_rsid) as index_variant_rsid,
+                              |  gene_id,
+                              |  any(r2) as r2,
+                              |  any(posterior_prob) as posterior_prob,
+                              |  any(pval) as pval
+                              | FROM #$d2v2gTName
+                              | PREWHERE
+                              |   chr_id = $chr and (
+                              |   (position >= $start and position <= $end) or
+                              |   (index_position >= $start and index_position <= $end) or
+                              |   (dictGetUInt32('gene','start',tuple(gene_id)) >= $start and
+                              |     dictGetUInt32('gene','start',tuple(gene_id)) <= $end) or
+                              |   (dictGetUInt32('gene','end',tuple(gene_id)) >= $start and
+                              |     dictGetUInt32('gene','end',tuple(gene_id)) <= $end))
+                              | group by stid, index_variant_id, variant_id, gene_id
+                              |) all inner join (
+                              | SELECT
+                              |   variant_id,
+                              |   gene_id,
+                              |   overall_score
+                              | FROM #$d2v2gOScoresTName
+                              | PREWHERE chr_id = $chr and
+                              | overall_score > 0.
+                              |) USING (variant_id, gene_id)
+                """.stripMargin
+              .as[GeckoLine]
+
+              db.run(
+                geneIdsInLoci.asTry zip assocs.asTry).map {
+                case (Success(geneIds), Success(assocs
+                )) => Entities.
+                  Gecko(assocs.view, geneIds.toSet)
+                case (Success(geneIds), Failure(
+                asscsEx)) =>
+                  logger.
+                    error(asscsEx.getMessage)
+                  Entities.Gecko(Seq.
+                    empty, geneIds.toSet)
+                case (_, _) =>
+                  logger.error("Something really wrong happened while getting geneIds from gene " +
+                    "dictionary and also from d2v2g table")
+                  Entities.Gecko(Seq.empty, Set.empty)
+              }
+            }
+
+      case (chrEither, rangeEither) =>
+        Future.failed(InputParameterCheckError(
+          Vector(chrEither, rangeEither).filter(_.isLeft).map(_.left.get).asInstanceOf[Vector[Violation]]))
+    }
+  }
 
   def buildG2VByVariant(variantId: String): Future[Seq[Entities.G2VAssociation]] = {
     val variant = DNA.Variant(variantId)

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -696,76 +696,76 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     }
   }
 
-  def buildG2VByGene(geneId: String): Future[Seq[Entities.G2VAssociation]] = {
-    val gene = Gene.apply(geneId)
-
-    gene match {
-      case Right(g) =>
-        val assocs = sql"""
-                          |SELECT
-                          |    gene_id,
-                          |    variant_id,
-                          |    overall_score,
-                          |    source_list,
-                          |    source_score_list,
-                          |    type_id,
-                          |    source_id,
-                          |    feature,
-                          |    fpred_max_label,
-                          |    fpred_max_score,
-                          |    qtl_beta,
-                          |    qtl_se,
-                          |    qtl_pval,
-                          |    interval_score,
-                          |    qtl_score_q,
-                          |    interval_score_q
-                          |FROM
-                          |(
-                          |    SELECT
-                          |        variant_id,
-                          |        type_id,
-                          |        source_id,
-                          |        feature,
-                          |        fpred_max_label,
-                          |        fpred_max_score,
-                          |        qtl_beta,
-                          |        qtl_se,
-                          |        qtl_pval,
-                          |        interval_score,
-                          |        qtl_score_q,
-                          |        interval_score_q
-                          |    FROM #$v2gTName
-                          |    PREWHERE
-                          |       (chr_id = dictGetString('gene', 'chr', tuple(${g.id}))) AND
-                          |       (gene_id = ${g.id}) AND
-                          |       (position >= (dictGetUInt32('gene', 'tss', tuple(${g.id})) - $defaultMaxDistantFromTSS)) AND
-                          |       (position <= (dictGetUInt32('gene', 'tss', tuple(${g.id})) + $defaultMaxDistantFromTSS)) AND
-                          |       (isNull(fpred_max_score) OR fpred_max_score > 0.)
-                          |)
-                          |ALL INNER JOIN
-                          |(
-                          |    SELECT
-                          |        variant_id,
-                          |        gene_id,
-                          |        source_list,
-                          |        source_score_list,
-                          |        overall_score
-                          |    FROM #$v2gOScoresTName
-                          |    PREWHERE (chr_id = dictGetString('gene','chr',tuple(${g.id}))) AND
-                          |       (gene_id = ${g.id})
-                          |) USING (variant_id)
-                          |ORDER BY variant_id ASC
-          """.stripMargin.as[ScoredG2VLine]
-
-        db.run(assocs.asTry).map {
-          case Success(r) => r.view.groupBy(_.variantId).mapValues(G2VAssociation(_)).values.toSeq
-          case Failure(ex) =>
-            logger.error(ex.getMessage)
-            Seq.empty
-        }
-      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
-    }
-  }
+//  def buildG2VByGene(geneId: String): Future[Seq[Entities.G2VAssociation]] = {
+//    val gene = Gene.apply(geneId)
+//
+//    gene match {
+//      case Right(g) =>
+//        val assocs = sql"""
+//                          |SELECT
+//                          |    gene_id,
+//                          |    variant_id,
+//                          |    overall_score,
+//                          |    source_list,
+//                          |    source_score_list,
+//                          |    type_id,
+//                          |    source_id,
+//                          |    feature,
+//                          |    fpred_max_label,
+//                          |    fpred_max_score,
+//                          |    qtl_beta,
+//                          |    qtl_se,
+//                          |    qtl_pval,
+//                          |    interval_score,
+//                          |    qtl_score_q,
+//                          |    interval_score_q
+//                          |FROM
+//                          |(
+//                          |    SELECT
+//                          |        variant_id,
+//                          |        type_id,
+//                          |        source_id,
+//                          |        feature,
+//                          |        fpred_max_label,
+//                          |        fpred_max_score,
+//                          |        qtl_beta,
+//                          |        qtl_se,
+//                          |        qtl_pval,
+//                          |        interval_score,
+//                          |        qtl_score_q,
+//                          |        interval_score_q
+//                          |    FROM #$v2gTName
+//                          |    PREWHERE
+//                          |       (chr_id = dictGetString('gene', 'chr', tuple(${g.id}))) AND
+//                          |       (gene_id = ${g.id}) AND
+//                          |       (position >= (dictGetUInt32('gene', 'tss', tuple(${g.id})) - $defaultMaxDistantFromTSS)) AND
+//                          |       (position <= (dictGetUInt32('gene', 'tss', tuple(${g.id})) + $defaultMaxDistantFromTSS)) AND
+//                          |       (isNull(fpred_max_score) OR fpred_max_score > 0.)
+//                          |)
+//                          |ALL INNER JOIN
+//                          |(
+//                          |    SELECT
+//                          |        variant_id,
+//                          |        gene_id,
+//                          |        source_list,
+//                          |        source_score_list,
+//                          |        overall_score
+//                          |    FROM #$v2gOScoresTName
+//                          |    PREWHERE (chr_id = dictGetString('gene','chr',tuple(${g.id}))) AND
+//                          |       (gene_id = ${g.id})
+//                          |) USING (variant_id)
+//                          |ORDER BY variant_id ASC
+//          """.stripMargin.as[ScoredG2VLine]
+//
+//        db.run(assocs.asTry).map {
+//          case Success(r) => r.view.groupBy(_.variantId).mapValues(G2VAssociation(_)).values.toSeq
+//          case Failure(ex) =>
+//            logger.error(ex.getMessage)
+//            Seq.empty
+//        }
+//      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
+//    }
+//  }
 
   private val v2dByStTName: String = "v2d_by_stchr"
   private val v2dByChrPosTName: String = "v2d_by_chrpos"

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -50,135 +50,135 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     config.get[Int]("ot.elasticsearch.port"))
   val esQ = HttpClient(esUri)
 
-  def buildPheWASTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
-  Future[Entities.PheWASTable] = {
-    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-    val variant = Variant(variantID)
+//  def buildPheWASTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
+//  Future[Entities.PheWASTable] = {
+//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
+//    val variant = Variant(variantID)
+//
+//    variant match {
+//      case Right(v) =>
+//        val segment = toSumStatsSegment(v.position.position)
+//        val tableName = gwasSumStatsTName format v.position.chrId
+//        val query =
+//          sql"""
+//               |select
+//               | study_id,
+//               | pval,
+//               | beta,
+//               | se,
+//               | eaf,
+//               | maf,
+//               | n_samples_variant_level,
+//               | n_samples_study_level,
+//               | n_cases_study_level,
+//               | n_cases_variant_level,
+//               | if(is_cc,exp(beta),NULL) as odds_ratio,
+//               | chip,
+//               | info
+//               |from #$tableName
+//               |prewhere chrom = ${v.position.chrId} and
+//               |  pos_b37 = ${v.position.position} and
+//               |  segment = $segment and
+//               |  variant_id_b37 = ${v.id}
+//               |#$limitClause
+//         """.stripMargin.as[VariantPheWAS]
+//
+//        dbSS.run(query.asTry).map {
+//          case Success(traitVector) => PheWASTable(traitVector)
+//          case Failure(ex) =>
+//            logger.error(ex.getMessage)
+//            PheWASTable(associations = Vector.empty)
+//        }
+//
+//      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
+//    }
+//  }
 
-    variant match {
-      case Right(v) =>
-        val segment = toSumStatsSegment(v.position.position)
-        val tableName = gwasSumStatsTName format v.position.chrId
-        val query =
-          sql"""
-               |select
-               | study_id,
-               | pval,
-               | beta,
-               | se,
-               | eaf,
-               | maf,
-               | n_samples_variant_level,
-               | n_samples_study_level,
-               | n_cases_study_level,
-               | n_cases_variant_level,
-               | if(is_cc,exp(beta),NULL) as odds_ratio,
-               | chip,
-               | info
-               |from #$tableName
-               |prewhere chrom = ${v.position.chrId} and
-               |  pos_b37 = ${v.position.position} and
-               |  segment = $segment and
-               |  variant_id_b37 = ${v.id}
-               |#$limitClause
-         """.stripMargin.as[VariantPheWAS]
+//  def getG2VSchema: Future[Entities.G2VSchema] = {
+//    def toSeqStruct(elems: Map[String, Map[String, String]]) = {
+//      (for {
+//        triple <- elems
+//        tuple <- triple._2
+//
+//      } yield Entities.G2VSchemaElement(triple._1, tuple._1,
+//        StrSeqRep(tuple._2).rep.map(el => Tissue(el)))).toSeq
+//    }
+//    val studyQ = sql"""
+//                      |select
+//                      | type_id,
+//                      | source_id,
+//                      | feature_set
+//                      |from #$v2gStructureTName
+//      """.stripMargin.as[(String, String, String)]
+//
+//    db.run(studyQ.asTry).map {
+//      case Success(v) =>
+//        val mappedRows = v.groupBy(_._1).mapValues(_.groupBy(_._2).mapValues(_.head._3))
+//        val qtlElems = toSeqStruct(mappedRows.filterKeys(defaultQtlTypes.contains(_)))
+//        val intervalElems = toSeqStruct(mappedRows.filterKeys(defaultIntervalTypes.contains(_)))
+//        val fpredElems = toSeqStruct(mappedRows.filterKeys(defaultFPredTypes.contains(_)))
+//
+//        G2VSchema(qtlElems, intervalElems, fpredElems)
+//      case Failure(ex) =>
+//        logger.error(ex.getMessage)
+//        G2VSchema(Seq.empty, Seq.empty, Seq.empty)
+//    }
+//  }
 
-        dbSS.run(query.asTry).map {
-          case Success(traitVector) => PheWASTable(traitVector)
-          case Failure(ex) =>
-            logger.error(ex.getMessage)
-            PheWASTable(associations = Vector.empty)
-        }
-
-      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
-    }
-  }
-
-  def getG2VSchema: Future[Entities.G2VSchema] = {
-    def toSeqStruct(elems: Map[String, Map[String, String]]) = {
-      (for {
-        triple <- elems
-        tuple <- triple._2
-
-      } yield Entities.G2VSchemaElement(triple._1, tuple._1,
-        StrSeqRep(tuple._2).rep.map(el => Tissue(el)))).toSeq
-    }
-    val studyQ = sql"""
-                      |select
-                      | type_id,
-                      | source_id,
-                      | feature_set
-                      |from #$v2gStructureTName
-      """.stripMargin.as[(String, String, String)]
-
-    db.run(studyQ.asTry).map {
-      case Success(v) =>
-        val mappedRows = v.groupBy(_._1).mapValues(_.groupBy(_._2).mapValues(_.head._3))
-        val qtlElems = toSeqStruct(mappedRows.filterKeys(defaultQtlTypes.contains(_)))
-        val intervalElems = toSeqStruct(mappedRows.filterKeys(defaultIntervalTypes.contains(_)))
-        val fpredElems = toSeqStruct(mappedRows.filterKeys(defaultFPredTypes.contains(_)))
-
-        G2VSchema(qtlElems, intervalElems, fpredElems)
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        G2VSchema(Seq.empty, Seq.empty, Seq.empty)
-    }
-  }
-
-  def getSearchResultSet(qString: String, pageIndex: Option[Int], pageSize: Option[Int]):
-  Future[Entities.SearchResultSet] = {
-    val limitClause = parsePaginationTokensForES(pageIndex, pageSize)
-    val stoken = qString.toLowerCase
-    // val stoken = qString
-    val cleanedTokens = stoken.replaceAll("-", " ")
-
-    if (stoken.length > 0) {
-      esQ.execute {
-          search("studies") query boolQuery.should(matchQuery("study_id", stoken),
-            matchQuery("pmid", stoken),
-            multiMatchQuery(cleanedTokens)
-              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
-              .lenient(true)
-              .slop(10)
-              .prefixLength(2)
-              .maxExpansions(50)
-              .operator("OR")
-              .analyzer(WhitespaceAnalyzer)
-              .fields(Map("trait_reported" -> 1.5F,
-                "pub_author" -> 1.2F,
-                "_all" -> 1.0F)),
-            simpleStringQuery(cleanedTokens)
-              .defaultOperator("AND")
-            ) start limitClause._1 limit limitClause._2 sortByFieldDesc "n_initial"
-      }.zip {
-        esQ.execute {
-          search("variant_*") query boolQuery.should(matchQuery("variant_id", stoken),
-            matchQuery("rs_id", stoken)) start limitClause._1 limit limitClause._2
-        }
-      }.zip {
-        esQ.execute {
-          search("genes") query boolQuery.should(matchQuery("gene_id", stoken),
-            matchQuery("gene_name", stoken),
-            multiMatchQuery(cleanedTokens)
-              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
-              .lenient(true)
-              .slop(10)
-              .prefixLength(2)
-              .maxExpansions(50)
-              .operator("OR")
-              .analyzer(WhitespaceAnalyzer)
-              .fields("gene_name")) start limitClause._1 limit limitClause._2
-        }
-      }.map{
-        case ((studiesRS, variantsRS), genesRS) =>
-          SearchResultSet(genesRS.totalHits, genesRS.to[FRM.Gene],
-            variantsRS.totalHits, variantsRS.to[VariantSearchResult],
-            studiesRS.totalHits, studiesRS.to[Study])
-      }
-    } else {
-      Future.failed(InputParameterCheckError(Vector(SearchStringViolation())))
-    }
-  }
+//  def getSearchResultSet(qString: String, pageIndex: Option[Int], pageSize: Option[Int]):
+//  Future[Entities.SearchResultSet] = {
+//    val limitClause = parsePaginationTokensForES(pageIndex, pageSize)
+//    val stoken = qString.toLowerCase
+//    // val stoken = qString
+//    val cleanedTokens = stoken.replaceAll("-", " ")
+//
+//    if (stoken.length > 0) {
+//      esQ.execute {
+//          search("studies") query boolQuery.should(matchQuery("study_id", stoken),
+//            matchQuery("pmid", stoken),
+//            multiMatchQuery(cleanedTokens)
+//              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
+//              .lenient(true)
+//              .slop(10)
+//              .prefixLength(2)
+//              .maxExpansions(50)
+//              .operator("OR")
+//              .analyzer(WhitespaceAnalyzer)
+//              .fields(Map("trait_reported" -> 1.5F,
+//                "pub_author" -> 1.2F,
+//                "_all" -> 1.0F)),
+//            simpleStringQuery(cleanedTokens)
+//              .defaultOperator("AND")
+//            ) start limitClause._1 limit limitClause._2 sortByFieldDesc "n_initial"
+//      }.zip {
+//        esQ.execute {
+//          search("variant_*") query boolQuery.should(matchQuery("variant_id", stoken),
+//            matchQuery("rs_id", stoken)) start limitClause._1 limit limitClause._2
+//        }
+//      }.zip {
+//        esQ.execute {
+//          search("genes") query boolQuery.should(matchQuery("gene_id", stoken),
+//            matchQuery("gene_name", stoken),
+//            multiMatchQuery(cleanedTokens)
+//              .matchType(MultiMatchQueryBuilder.Type.PHRASE_PREFIX)
+//              .lenient(true)
+//              .slop(10)
+//              .prefixLength(2)
+//              .maxExpansions(50)
+//              .operator("OR")
+//              .analyzer(WhitespaceAnalyzer)
+//              .fields("gene_name")) start limitClause._1 limit limitClause._2
+//        }
+//      }.map{
+//        case ((studiesRS, variantsRS), genesRS) =>
+//          SearchResultSet(genesRS.totalHits, genesRS.to[FRM.Gene],
+//            variantsRS.totalHits, variantsRS.to[VariantSearchResult],
+//            studiesRS.totalHits, studiesRS.to[FRM.Study])
+//      }
+//    } else {
+//      Future.failed(InputParameterCheckError(Vector(SearchStringViolation())))
+//    }
+//  }
 
   /** get top Functions.defaultTopOverlapStudiesSize studies sorted desc by
     * the number of overlapped loci
@@ -186,521 +186,402 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
     * @param stid given a study ID
     * @return a Entities.OverlappedLociStudy which could contain empty list of ovelapped studies
     */
-  def getTopOverlappedStudies(stid: String, pageIndex: Option[Int] = Some(0), pageSize: Option[Int] = Some(defaultTopOverlapStudiesSize)):
-  Future[Entities.OverlappedLociStudy] = {
-    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-
-    val topOverlappedsSQL = sql"""
-                          |SELECT
-                          |  study_id_b,
-                          |  uniq(index_variant_id_a) AS num_overlap_loci
-                          |FROM #$studiesOverlapTName
-                          |PREWHERE (study_id_a = $stid) and
-                          |  set_type = 'combined'
-                          |GROUP BY
-                          |  study_id_a,
-                          |  study_id_b
-                          |ORDER BY num_overlap_loci desc
-                          |#$limitClause
-      """.stripMargin.as[(String, Int)]
-
-    db.run(topOverlappedsSQL.asTry).map {
-      case Success(v) =>
-        if (v.nonEmpty) {
-          OverlappedLociStudy(stid, v.map(t => OverlapRow(t._1, t._2)))
-        } else {
-          OverlappedLociStudy(stid, Vector.empty)
-        }
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        OverlappedLociStudy(stid, Vector.empty)
-    }
-  }
-
-  def getOverlapVariantsIntersectionForStudies(stid: String, stids: Seq[String]): Future[Vector[String]] = {
-    val stidListString = stids.map("'" + _ + "'").mkString(",")
-    val numStids = if (stids.nonEmpty) stids.length else 0
-    val overlapSQL = sql"""
-                          |SELECT index_variant_id_a
-                          |FROM
-                          |(
-                          |    SELECT
-                          |        index_variant_id_a,
-                          |        uniq(study_id_b) AS num_studies
-                          |    FROM #$studiesOverlapTName
-                          |    PREWHERE (study_id_a = $stid) AND
-                          |        (study_id_b IN (#${stidListString})) AND
-                          |        (set_type = 'combined')
-                          |    GROUP BY index_variant_id_a
-                          |    HAVING num_studies = ${numStids}
-                          |)
-      """.stripMargin.as[String]
-
-    db.run(overlapSQL.asTry).map {
-      case Success(v) => v
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        Vector.empty
-    }
-  }
-
-  def getOverlapVariantsForStudies(stid: String, stids: Seq[String]): Future[Vector[Entities.OverlappedVariantsStudy]] = {
-    val stidListString = stids.map("'" + _ + "'").mkString(",")
-    val overlapSQL = sql"""
-                          |SELECT
-                          |  study_id_b,
-                          |  index_variant_id_a,
-                          |  index_variant_id_b,
-                          |  any(overlap_AB) AS overlap_AB,
-                          |  any(distinct_A) AS distinct_A,
-                          |  any(distinct_B) AS distinct_B
-                          |FROM #$studiesOverlapTName
-                          |PREWHERE (study_id_a = $stid) AND
-                          |  (study_id_b IN (#${stidListString})) AND
-                          |  (set_type = 'combined')
-                          |GROUP BY
-                          |  study_id_a,
-                          |  study_id_b,
-                          |  index_variant_id_a,
-                          |  index_variant_id_b
-      """.stripMargin.as[(String, String, String, Int, Int, Int)]
-
-    db.run(overlapSQL.asTry).map {
-      case Success(v) =>
-        if (v.nonEmpty) {
-          v.view.groupBy(_._1).map(pair =>
-            OverlappedVariantsStudy(pair._1,
-              pair._2.map(t => OverlappedVariant(t._2, t._3, t._4, t._5, t._6)))).toVector
-        } else {
-          Vector.empty
-        }
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        Vector.empty
-    }
-  }
-
-  def getStudiesForGene(geneId: String): Future[Vector[String]] = {
-    val studiesSQL = sql"""
-                           |SELECT DISTINCT stid
-                           |FROM #$d2v2gTName
-                           |PREWHERE
-                           |  (gene_id = $geneId) AND
-                           |  (chr_id = dictGetString('gene','chr',tuple($geneId)))
-      """.stripMargin.as[String]
-
-    db.run(studiesSQL.asTry).map {
-      case Success(v) => v
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        Vector.empty
-    }
-  }
-
-  def getGenes(geneIds: Seq[String]): Future[Seq[FRM.Gene]] = {
-    val q = for {
-      g <- FRM.genes
-      if g.id inSetBind geneIds
-    } yield g
-
-    db.run(q.result.asTry).map {
-      case Success(v) => v
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        Vector.empty
-    }
-
-//    val geneIdsList = geneIds.map("'" + _ + "'").mkString(",")
-//    val genesSql = sql"""
-//                          |SELECT
-//                          | gene_id,
-//                          | gene_name,
-//                          | biotype,
-//                          | chr,
-//                          | tss,
-//                          | start,
-//                          | end,
-//                          | fwdstrand,
-//                          | cast(exons, 'Array(UInt32)') AS exons
-//                          |FROM #$genesTName
-//                          |WHERE gene_id IN (#${geneIdsList})
-//      """.stripMargin.as[DNA.Gene]
+//  def getTopOverlappedStudies(stid: String, pageIndex: Option[Int] = Some(0), pageSize: Option[Int] = Some(defaultTopOverlapStudiesSize)):
+//  Future[Entities.OverlappedLociStudy] = {
+//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
 //
-//    db.run(genesSql.asTry).map {
+//    val topOverlappedsSQL = sql"""
+//                          |SELECT
+//                          |  study_id_b,
+//                          |  uniq(index_variant_id_a) AS num_overlap_loci
+//                          |FROM #$studiesOverlapTName
+//                          |PREWHERE (study_id_a = $stid) and
+//                          |  set_type = 'combined'
+//                          |GROUP BY
+//                          |  study_id_a,
+//                          |  study_id_b
+//                          |ORDER BY num_overlap_loci desc
+//                          |#$limitClause
+//      """.stripMargin.as[(String, Int)]
+//
+//    db.run(topOverlappedsSQL.asTry).map {
+//      case Success(v) =>
+//        if (v.nonEmpty) {
+//          OverlappedLociStudy(stid, v.map(t => OverlapRow(t._1, t._2)))
+//        } else {
+//          OverlappedLociStudy(stid, Vector.empty)
+//        }
+//      case Failure(ex) =>
+//        logger.error(ex.getMessage)
+//        OverlappedLociStudy(stid, Vector.empty)
+//    }
+//  }
+
+//  def getOverlapVariantsIntersectionForStudies(stid: String, stids: Seq[String]): Future[Vector[String]] = {
+//    val stidListString = stids.map("'" + _ + "'").mkString(",")
+//    val numStids = if (stids.nonEmpty) stids.length else 0
+//    val overlapSQL = sql"""
+//                          |SELECT index_variant_id_a
+//                          |FROM
+//                          |(
+//                          |    SELECT
+//                          |        index_variant_id_a,
+//                          |        uniq(study_id_b) AS num_studies
+//                          |    FROM #$studiesOverlapTName
+//                          |    PREWHERE (study_id_a = $stid) AND
+//                          |        (study_id_b IN (#${stidListString})) AND
+//                          |        (set_type = 'combined')
+//                          |    GROUP BY index_variant_id_a
+//                          |    HAVING num_studies = ${numStids}
+//                          |)
+//      """.stripMargin.as[String]
+//
+//    db.run(overlapSQL.asTry).map {
 //      case Success(v) => v
 //      case Failure(ex) =>
 //        logger.error(ex.getMessage)
 //        Vector.empty
 //    }
+//  }
+
+//  def getOverlapVariantsForStudies(stid: String, stids: Seq[String]): Future[Vector[Entities.OverlappedVariantsStudy]] = {
+//    val stidListString = stids.map("'" + _ + "'").mkString(",")
+//    val overlapSQL = sql"""
+//                          |SELECT
+//                          |  study_id_b,
+//                          |  index_variant_id_a,
+//                          |  index_variant_id_b,
+//                          |  any(overlap_AB) AS overlap_AB,
+//                          |  any(distinct_A) AS distinct_A,
+//                          |  any(distinct_B) AS distinct_B
+//                          |FROM #$studiesOverlapTName
+//                          |PREWHERE (study_id_a = $stid) AND
+//                          |  (study_id_b IN (#${stidListString})) AND
+//                          |  (set_type = 'combined')
+//                          |GROUP BY
+//                          |  study_id_a,
+//                          |  study_id_b,
+//                          |  index_variant_id_a,
+//                          |  index_variant_id_b
+//      """.stripMargin.as[(String, String, String, Int, Int, Int)]
+//
+//    db.run(overlapSQL.asTry).map {
+//      case Success(v) =>
+//        if (v.nonEmpty) {
+//          v.view.groupBy(_._1).map(pair =>
+//            OverlappedVariantsStudy(pair._1,
+//              pair._2.map(t => OverlappedVariant(t._2, t._3, t._4, t._5, t._6)))).toVector
+//        } else {
+//          Vector.empty
+//        }
+//      case Failure(ex) =>
+//        logger.error(ex.getMessage)
+//        Vector.empty
+//    }
+//  }
+
+//  def getStudiesForGene(geneId: String): Future[Vector[String]] = {
+//    val studiesSQL = sql"""
+//                           |SELECT DISTINCT stid
+//                           |FROM #$d2v2gTName
+//                           |PREWHERE
+//                           |  (gene_id = $geneId) AND
+//                           |  (chr_id = dictGetString('gene','chr',tuple($geneId)))
+//      """.stripMargin.as[String]
+//
+//    db.run(studiesSQL.asTry).map {
+//      case Success(v) => v
+//      case Failure(ex) =>
+//        logger.error(ex.getMessage)
+//        Vector.empty
+//    }
+//  }
+
+  def getGenes(geneIds: Seq[String]): Future[Seq[FRM.Gene]] = {
+    if (geneIds.nonEmpty) {
+      val q = for {
+        g <- FRM.genes
+        if g.id inSetBind geneIds
+      } yield g
+
+      db.run(q.result.asTry).map {
+        case Success(v) => v
+        case Failure(ex) =>
+          logger.error(ex.getMessage)
+          Seq.empty
+      }
+    } else {
+      Future.successful(Seq.empty)
+    }
   }
 
   /** query variants table with a list of variant ids and get all related information */
-  def getVariants(variantIds: Seq[String]): Future[Vector[DNA.Variant]] = {
+  def getVariants(variantIds: Seq[String]): Future[Seq[FRM.Variant]] = {
     if (variantIds.nonEmpty) {
-      val variantIdsSet = variantIds.map("'" + _ + "'").mkString(",")
-      val variants = variantIds.map(Variant(_)).withFilter(_.isRight).map(_.right.get)
+      val q = for {
+        v <- FRM.variants
+        if v.id inSetBind variantIds
+      } yield v
 
-      val vListQ = sql"""
-                        |select
-                        | chr_id,
-                        | position,
-                        | ref_allele,
-                        | alt_allele,
-                        | rs_id,
-                        | gene_id,
-                        | gene_id_prot_coding
-                        |from #$variantsTName
-                        |prewhere variant_id IN (#${variantIdsSet})
-        """.stripMargin.as[Variant]
-
-      db.run(vListQ.asTry).map {
-        case Success(v) =>
-          /*
-          NOTE this is a hack as we have toploci variants wihch are not coming from
-          the vcf file provided by Ensembl see 3_194061907_G_A as an example
-           */
-          val vIds = v.map(_.id)
-          v ++ variants.filter(vv => (variantIds diff vIds).contains(vv.id))
+      db.run(q.result.asTry).map {
+        case Success(v) => v
         case Failure(ex) =>
           logger.error(ex.getMessage)
-          Vector.empty
+          Seq.empty
       }
     } else {
-      Future.successful(Vector.empty)
+      Future.successful(Seq.empty)
     }
   }
 
-  def getStudies(stids: Seq[String]): Future[Vector[Entities.Study]] = {
-    val stidListString = stids.map("'" + _ + "'").mkString(",")
-    val studiesSQL = sql"""
-                      |select
-                      | study_id,
-                      | trait_code,
-                      | trait_reported,
-                      | trait_efos,
-                      | pmid,
-                      | pub_date,
-                      | pub_journal,
-                      | pub_title,
-                      | pub_author,
-                      | ancestry_initial,
-                      | ancestry_replication,
-                      | n_initial,
-                      | n_replication,
-                      | n_cases,
-                      | trait_category
-                      |from #$studiesTName
-                      |where study_id in (#${stidListString})
-      """.stripMargin.as[Study](getStudy)
+  def getStudies(stids: Seq[String]): Future[Seq[FRM.Study]] = {
+    if (stids.nonEmpty) {
+      val q = for {
+        v <- FRM.studies
+        if v.studyId inSetBind stids
+      } yield v
 
-    db.run(studiesSQL.asTry).map {
-      case Success(v) => v
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        Vector.empty
+      db.run(q.result.asTry).map {
+        case Success(v) => v
+        case Failure(ex) =>
+          logger.error(ex.getMessage)
+          Seq.empty
+      }
+    } else {
+      Future.successful(Seq.empty)
     }
   }
 
-  def buildManhattanTable(studyId: String, pageIndex: Option[Int], pageSize: Option[Int]):
-  Future[Entities.ManhattanTable] = {
-    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-
-    val idxVariants = sql"""
-      |SELECT
-      |    index_variant_id,
-      |    pval,
-      |    credibleSetSize,
-      |    ldSetSize,
-      |    uniq_variants,
-      |    top_genes_ids,
-      |    top_genes_scores
-      |FROM
-      |(
-      |    SELECT
-      |        index_variant_id,
-      |        any(pval) AS pval,
-      |        uniqIf(variant_id, posterior_prob > 0) AS credibleSetSize,
-      |        uniqIf(variant_id, r2 > 0) AS ldSetSize,
-      |        uniq(variant_id) AS uniq_variants
-      |    FROM #$v2dByStTName
-      |    PREWHERE stid = $studyId
-      |    GROUP BY index_variant_id
-      |)
-      |ALL LEFT OUTER JOIN
-      |(
-      |    SELECT
-      |        variant_id AS index_variant_id,
-      |        groupArray(gene_id) AS top_genes_ids,
-      |        groupArray(overall_score) AS top_genes_scores
-      |    FROM ot.d2v2g_score_by_overall
-      |    PREWHERE (variant_id = index_variant_id) AND (overall_score > 0.)
-      |    GROUP BY variant_id
-      |) USING (index_variant_id)
-      |#$limitClause
-      """.stripMargin.as[V2DByStudy]
-
-    // map to proper manhattan association with needed fields
-    db.run(idxVariants.asTry).map {
-      case Success(v) => ManhattanTable(studyId,
-        v.map(el => {
-          ManhattanAssociation(el.index_variant_id, el.pval, el.topGenes,
-            el.credibleSetSize, el.ldSetSize, el.totalSetSize)
-        })
-      )
-      case Failure(ex) =>
-        logger.error(ex.getMessage)
-        ManhattanTable(studyId, associations = Vector.empty)
-    }
-  }
-
-  def buildIndexVariantAssocTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
-  Future[Entities.IndexVariantTable] = {
-    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-    val variant = Variant(variantID)
-
-    variant match {
-      case Right(v) =>
-        val assocs = sql"""
-                       |select
-                       | variant_id,
-                       | rs_id,
-                       | stid,
-                       | pval,
-                       | ifNull(n_initial,0) + ifNull(n_replication,0),
-                       | ifNull(n_cases, 0),
-                       | r2,
-                       | afr_1000g_prop,
-                       | amr_1000g_prop,
-                       | eas_1000g_prop,
-                       | eur_1000g_prop,
-                       | sas_1000g_prop,
-                       | log10_abf,
-                       | posterior_prob
-                       |from #$v2dByChrPosTName
-                       |prewhere
-                       |  chr_id = ${v.position.chrId} and
-                       |  index_position = ${v.position.position} and
-                       |  index_ref_allele = ${v.refAllele} and
-                       |  index_alt_allele = ${v.altAllele}
-                       |#$limitClause
-          """.stripMargin.as[IndexVariantAssociation]
-
-        db.run(assocs.asTry).map {
-          case Success(r) => Entities.IndexVariantTable(r)
-          case Failure(ex) =>
-            logger.error(ex.getMessage)
-            Entities.IndexVariantTable(associations = Vector.empty)
-        }
-      case Left(violation) =>
-        Future.failed(InputParameterCheckError(Vector(violation)))
-    }
-  }
-
-  def buildTagVariantAssocTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
-  Future[TagVariantTable] = {
-    val limitClause = parsePaginationTokens(pageIndex, pageSize)
-    val variant = Variant(variantID)
-
-    variant match {
-      case Right(v) =>
-        val assocs = sql"""
-                          |select
-                          | index_variant_id,
-                          | index_rs_id,
-                          | stid,
-                          | pval,
-                          | ifNull(n_initial,0) + ifNull(n_replication,0),
-                          | ifNull(n_cases, 0),
-                          | r2,
-                          | afr_1000g_prop,
-                          | amr_1000g_prop,
-                          | eas_1000g_prop,
-                          | eur_1000g_prop,
-                          | sas_1000g_prop,
-                          | log10_abf,
-                          | posterior_prob
-                          |from #$v2dByChrPosTName
-                          |prewhere
-                          |  chr_id = ${v.position.chrId} and
-                          |  position = ${v.position.position} and
-                          |  ref_allele = ${v.refAllele} and
-                          |  alt_allele = ${v.altAllele}
-                          |#$limitClause
-          """.stripMargin.as[TagVariantAssociation]
-
-        // map to proper manhattan association with needed fields
-        db.run(assocs.asTry).map {
-          case Success(r) => Entities.TagVariantTable(r)
-          case Failure(ex) =>
-            logger.error(ex.getMessage)
-            Entities.TagVariantTable(associations = Vector.empty)
-        }
-      case Left(violation) =>
-        Future.failed(InputParameterCheckError(Vector(violation)))
-    }
-  }
-
-  def buildGecko(chromosome: String, posStart: Long, posEnd: Long): Future[Option[Entities.Gecko]] = {
-    (parseChromosome(chromosome), parseRegion(posStart, posEnd)) match {
-      case (Right(chr), Right((start, end))) =>
-        val inRegion = Region(chr, start, end)
-        if (denseRegionChecker.matchRegion(inRegion)) {
-          Future.failed(InputParameterCheckError(Vector(RegionViolation(inRegion))))
-        } else {
-            val geneIdsInLoci = sql"""
-                                     |SELECT
-                                     | gene_id
-                                     |FROM ot.gene
-                                     |WHERE
-                                     | chr = $chr and (
-                                     | (start >= $start and start <= $end) or
-                                     | (end >= $start and end <= $end))
-                """.stripMargin.as[String]
-
-            val assocs = sql"""
-                              |SELECT
-                              |  variant_id,
-                              |  rs_id,
-                              |  index_variant_id,
-                              |  index_variant_rsid,
-                              |  gene_id,
-                              |  stid,
-                              |  r2,
-                              |  posterior_prob,
-                              |  pval,
-                              |  overall_score
-                              |FROM (
-                              | SELECT
-                              |  stid,
-                              |  variant_id,
-                              |  any(rs_id) as rs_id,
-                              |  index_variant_id,
-                              |  any(index_variant_rsid) as index_variant_rsid,
-                              |  gene_id,
-                              |  any(r2) as r2,
-                              |  any(posterior_prob) as posterior_prob,
-                              |  any(pval) as pval
-                              | FROM #$d2v2gTName
-                              | PREWHERE
-                              |   chr_id = $chr and (
-                              |   (position >= $start and position <= $end) or
-                              |   (index_position >= $start and index_position <= $end) or
-                              |   (dictGetUInt32('gene','start',tuple(gene_id)) >= $start and
-                              |     dictGetUInt32('gene','start',tuple(gene_id)) <= $end) or
-                              |   (dictGetUInt32('gene','end',tuple(gene_id)) >= $start and
-                              |     dictGetUInt32('gene','end',tuple(gene_id)) <= $end))
-                              | group by stid, index_variant_id, variant_id, gene_id
-                              |) all inner join (
-                              | SELECT
-                              |   variant_id,
-                              |   gene_id,
-                              |   overall_score
-                              | FROM #$d2v2gOScoresTName
-                              | PREWHERE chr_id = $chr and
-                              | overall_score > 0.
-                              |) USING (variant_id, gene_id)
-                """.stripMargin
-              .as[GeckoLine]
-
-              db.run(
-                geneIdsInLoci.asTry zip assocs.asTry).map {
-                case (Success(geneIds), Success(assocs
-                )) => Entities.
-                  Gecko(assocs.view, geneIds.toSet)
-                case (Success(geneIds), Failure(
-                asscsEx)) =>
-                  logger.
-                    error(asscsEx.getMessage)
-                  Entities.Gecko(Seq.
-                    empty, geneIds.toSet)
-                case (_, _) =>
-                  logger.error("Something really wrong happened while getting geneIds from gene " +
-                    "dictionary and also from d2v2g table")
-                  Entities.Gecko(Seq.empty, Set.empty)
-              }
-            }
-
-      case (chrEither, rangeEither) =>
-        Future.failed(InputParameterCheckError(
-          Vector(chrEither, rangeEither).filter(_.isLeft).map(_.left.get).asInstanceOf[Vector[Violation]]))
-    }
-  }
-
-  def buildG2VByVariant(variantId: String): Future[Seq[Entities.G2VAssociation]] = {
-    val variant = Variant(variantId)
-
-    variant match {
-      case Right(v) =>
-        val assocs = sql"""
-                          |SELECT
-                          |    gene_id,
-                          |    variant_id,
-                          |    overall_score,
-                          |    source_list,
-                          |    source_score_list,
-                          |    type_id,
-                          |    source_id,
-                          |    feature,
-                          |    fpred_max_label,
-                          |    fpred_max_score,
-                          |    qtl_beta,
-                          |    qtl_se,
-                          |    qtl_pval,
-                          |    interval_score,
-                          |    qtl_score_q,
-                          |    interval_score_q
-                          |FROM
-                          |(
-                          |    SELECT
-                          |        gene_id,
-                          |        type_id,
-                          |        source_id,
-                          |        feature,
-                          |        fpred_max_label,
-                          |        fpred_max_score,
-                          |        qtl_beta,
-                          |        qtl_se,
-                          |        qtl_pval,
-                          |        interval_score,
-                          |        qtl_score_q,
-                          |        interval_score_q
-                          |    FROM #$v2gTName
-                          |    PREWHERE
-                          |       (chr_id = ${v.position.chrId}) AND
-                          |       (position = ${v.position.position}) AND
-                          |       (variant_id = ${v.id}) AND
-                          |       (isNull(fpred_max_score) OR fpred_max_score > 0.)
-                          |)
-                          |ALL INNER JOIN
-                          |(
-                          |    SELECT
-                          |        variant_id,
-                          |        gene_id,
-                          |        source_list,
-                          |        source_score_list,
-                          |        overall_score
-                          |    FROM #$v2gOScoresTName
-                          |    PREWHERE (chr_id = ${v.position.chrId}) AND
-                          |       (variant_id = ${v.id})
-                          |) USING (gene_id)
-                          |ORDER BY gene_id ASC
-          """.stripMargin.as[ScoredG2VLine]
-
-        db.run(assocs.asTry).map {
-          case Success(r) => r.view.groupBy(_.geneId).mapValues(G2VAssociation(_)).values.toSeq
-          case Failure(ex) =>
-            logger.error(ex.getMessage)
-            Seq.empty
-        }
-      case Left(violation) => Future.failed(InputParameterCheckError(Vector(violation)))
-    }
-  }
-
-//  def buildG2VByGene(geneId: String): Future[Seq[Entities.G2VAssociation]] = {
-//    val gene = Gene.apply(geneId)
+//  def buildManhattanTable(studyId: String, pageIndex: Option[Int], pageSize: Option[Int]):
+//  Future[Entities.ManhattanTable] = {
+//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
 //
-//    gene match {
-//      case Right(g) =>
+//    val idxVariants = sql"""
+//      |SELECT
+//      |    index_variant_id,
+//      |    pval,
+//      |    credibleSetSize,
+//      |    ldSetSize,
+//      |    uniq_variants,
+//      |    top_genes_ids,
+//      |    top_genes_scores
+//      |FROM
+//      |(
+//      |    SELECT
+//      |        index_variant_id,
+//      |        any(pval) AS pval,
+//      |        uniqIf(variant_id, posterior_prob > 0) AS credibleSetSize,
+//      |        uniqIf(variant_id, r2 > 0) AS ldSetSize,
+//      |        uniq(variant_id) AS uniq_variants
+//      |    FROM #$v2dByStTName
+//      |    PREWHERE stid = $studyId
+//      |    GROUP BY index_variant_id
+//      |)
+//      |ALL LEFT OUTER JOIN
+//      |(
+//      |    SELECT
+//      |        variant_id AS index_variant_id,
+//      |        groupArray(gene_id) AS top_genes_ids,
+//      |        groupArray(overall_score) AS top_genes_scores
+//      |    FROM ot.d2v2g_score_by_overall
+//      |    PREWHERE (variant_id = index_variant_id) AND (overall_score > 0.)
+//      |    GROUP BY variant_id
+//      |) USING (index_variant_id)
+//      |#$limitClause
+//      """.stripMargin.as[V2DByStudy]
+//
+//    // map to proper manhattan association with needed fields
+//    db.run(idxVariants.asTry).map {
+//      case Success(v) => ManhattanTable(studyId,
+//        v.map(el => {
+//          ManhattanAssociation(el.index_variant_id, el.pval, el.topGenes,
+//            el.credibleSetSize, el.ldSetSize, el.totalSetSize)
+//        })
+//      )
+//      case Failure(ex) =>
+//        logger.error(ex.getMessage)
+//        ManhattanTable(studyId, associations = Vector.empty)
+//    }
+//  }
+
+//  def buildIndexVariantAssocTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
+//  Future[Entities.IndexVariantTable] = {
+//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
+//    val variant = Variant(variantID)
+//
+//    variant match {
+//      case Right(v) =>
+//        val assocs = sql"""
+//                       |select
+//                       | variant_id,
+//                       | rs_id,
+//                       | stid,
+//                       | pval,
+//                       | ifNull(n_initial,0) + ifNull(n_replication,0),
+//                       | ifNull(n_cases, 0),
+//                       | r2,
+//                       | afr_1000g_prop,
+//                       | amr_1000g_prop,
+//                       | eas_1000g_prop,
+//                       | eur_1000g_prop,
+//                       | sas_1000g_prop,
+//                       | log10_abf,
+//                       | posterior_prob
+//                       |from #$v2dByChrPosTName
+//                       |prewhere
+//                       |  chr_id = ${v.position.chrId} and
+//                       |  index_position = ${v.position.position} and
+//                       |  index_ref_allele = ${v.refAllele} and
+//                       |  index_alt_allele = ${v.altAllele}
+//                       |#$limitClause
+//          """.stripMargin.as[IndexVariantAssociation]
+//
+//        db.run(assocs.asTry).map {
+//          case Success(r) => Entities.IndexVariantTable(r)
+//          case Failure(ex) =>
+//            logger.error(ex.getMessage)
+//            Entities.IndexVariantTable(associations = Vector.empty)
+//        }
+//      case Left(violation) =>
+//        Future.failed(InputParameterCheckError(Vector(violation)))
+//    }
+//  }
+
+//  def buildTagVariantAssocTable(variantID: String, pageIndex: Option[Int], pageSize: Option[Int]):
+//  Future[TagVariantTable] = {
+//    val limitClause = parsePaginationTokens(pageIndex, pageSize)
+//    val variant = Variant(variantID)
+//
+//    variant match {
+//      case Right(v) =>
+//        val assocs = sql"""
+//                          |select
+//                          | index_variant_id,
+//                          | index_rs_id,
+//                          | stid,
+//                          | pval,
+//                          | ifNull(n_initial,0) + ifNull(n_replication,0),
+//                          | ifNull(n_cases, 0),
+//                          | r2,
+//                          | afr_1000g_prop,
+//                          | amr_1000g_prop,
+//                          | eas_1000g_prop,
+//                          | eur_1000g_prop,
+//                          | sas_1000g_prop,
+//                          | log10_abf,
+//                          | posterior_prob
+//                          |from #$v2dByChrPosTName
+//                          |prewhere
+//                          |  chr_id = ${v.position.chrId} and
+//                          |  position = ${v.position.position} and
+//                          |  ref_allele = ${v.refAllele} and
+//                          |  alt_allele = ${v.altAllele}
+//                          |#$limitClause
+//          """.stripMargin.as[TagVariantAssociation]
+//
+//        // map to proper manhattan association with needed fields
+//        db.run(assocs.asTry).map {
+//          case Success(r) => Entities.TagVariantTable(r)
+//          case Failure(ex) =>
+//            logger.error(ex.getMessage)
+//            Entities.TagVariantTable(associations = Vector.empty)
+//        }
+//      case Left(violation) =>
+//        Future.failed(InputParameterCheckError(Vector(violation)))
+//    }
+//  }
+
+//  def buildGecko(chromosome: String, posStart: Long, posEnd: Long): Future[Option[Entities.Gecko]] = {
+//    (parseChromosome(chromosome), parseRegion(posStart, posEnd)) match {
+//      case (Right(chr), Right((start, end))) =>
+//        val inRegion = Region(chr, start, end)
+//        if (denseRegionChecker.matchRegion(inRegion)) {
+//          Future.failed(InputParameterCheckError(Vector(RegionViolation(inRegion))))
+//        } else {
+//            val geneIdsInLoci = sql"""
+//                                     |SELECT
+//                                     | gene_id
+//                                     |FROM ot.gene
+//                                     |WHERE
+//                                     | chr = $chr and (
+//                                     | (start >= $start and start <= $end) or
+//                                     | (end >= $start and end <= $end))
+//                """.stripMargin.as[String]
+//
+//            val assocs = sql"""
+//                              |SELECT
+//                              |  variant_id,
+//                              |  rs_id,
+//                              |  index_variant_id,
+//                              |  index_variant_rsid,
+//                              |  gene_id,
+//                              |  stid,
+//                              |  r2,
+//                              |  posterior_prob,
+//                              |  pval,
+//                              |  overall_score
+//                              |FROM (
+//                              | SELECT
+//                              |  stid,
+//                              |  variant_id,
+//                              |  any(rs_id) as rs_id,
+//                              |  index_variant_id,
+//                              |  any(index_variant_rsid) as index_variant_rsid,
+//                              |  gene_id,
+//                              |  any(r2) as r2,
+//                              |  any(posterior_prob) as posterior_prob,
+//                              |  any(pval) as pval
+//                              | FROM #$d2v2gTName
+//                              | PREWHERE
+//                              |   chr_id = $chr and (
+//                              |   (position >= $start and position <= $end) or
+//                              |   (index_position >= $start and index_position <= $end) or
+//                              |   (dictGetUInt32('gene','start',tuple(gene_id)) >= $start and
+//                              |     dictGetUInt32('gene','start',tuple(gene_id)) <= $end) or
+//                              |   (dictGetUInt32('gene','end',tuple(gene_id)) >= $start and
+//                              |     dictGetUInt32('gene','end',tuple(gene_id)) <= $end))
+//                              | group by stid, index_variant_id, variant_id, gene_id
+//                              |) all inner join (
+//                              | SELECT
+//                              |   variant_id,
+//                              |   gene_id,
+//                              |   overall_score
+//                              | FROM #$d2v2gOScoresTName
+//                              | PREWHERE chr_id = $chr and
+//                              | overall_score > 0.
+//                              |) USING (variant_id, gene_id)
+//                """.stripMargin
+//              .as[GeckoLine]
+//
+//              db.run(
+//                geneIdsInLoci.asTry zip assocs.asTry).map {
+//                case (Success(geneIds), Success(assocs
+//                )) => Entities.
+//                  Gecko(assocs.view, geneIds.toSet)
+//                case (Success(geneIds), Failure(
+//                asscsEx)) =>
+//                  logger.
+//                    error(asscsEx.getMessage)
+//                  Entities.Gecko(Seq.
+//                    empty, geneIds.toSet)
+//                case (_, _) =>
+//                  logger.error("Something really wrong happened while getting geneIds from gene " +
+//                    "dictionary and also from d2v2g table")
+//                  Entities.Gecko(Seq.empty, Set.empty)
+//              }
+//            }
+//
+//      case (chrEither, rangeEither) =>
+//        Future.failed(InputParameterCheckError(
+//          Vector(chrEither, rangeEither).filter(_.isLeft).map(_.left.get).asInstanceOf[Vector[Violation]]))
+//    }
+//  }
+
+//  def buildG2VByVariant(variantId: String): Future[Seq[Entities.G2VAssociation]] = {
+//    val variant = Variant(variantId)
+//
+//    variant match {
+//      case Right(v) =>
 //        val assocs = sql"""
 //                          |SELECT
 //                          |    gene_id,
@@ -722,7 +603,7 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
 //                          |FROM
 //                          |(
 //                          |    SELECT
-//                          |        variant_id,
+//                          |        gene_id,
 //                          |        type_id,
 //                          |        source_id,
 //                          |        feature,
@@ -736,10 +617,9 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
 //                          |        interval_score_q
 //                          |    FROM #$v2gTName
 //                          |    PREWHERE
-//                          |       (chr_id = dictGetString('gene', 'chr', tuple(${g.id}))) AND
-//                          |       (gene_id = ${g.id}) AND
-//                          |       (position >= (dictGetUInt32('gene', 'tss', tuple(${g.id})) - $defaultMaxDistantFromTSS)) AND
-//                          |       (position <= (dictGetUInt32('gene', 'tss', tuple(${g.id})) + $defaultMaxDistantFromTSS)) AND
+//                          |       (chr_id = ${v.position.chrId}) AND
+//                          |       (position = ${v.position.position}) AND
+//                          |       (variant_id = ${v.id}) AND
 //                          |       (isNull(fpred_max_score) OR fpred_max_score > 0.)
 //                          |)
 //                          |ALL INNER JOIN
@@ -751,14 +631,14 @@ class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider
 //                          |        source_score_list,
 //                          |        overall_score
 //                          |    FROM #$v2gOScoresTName
-//                          |    PREWHERE (chr_id = dictGetString('gene','chr',tuple(${g.id}))) AND
-//                          |       (gene_id = ${g.id})
-//                          |) USING (variant_id)
-//                          |ORDER BY variant_id ASC
+//                          |    PREWHERE (chr_id = ${v.position.chrId}) AND
+//                          |       (variant_id = ${v.id})
+//                          |) USING (gene_id)
+//                          |ORDER BY gene_id ASC
 //          """.stripMargin.as[ScoredG2VLine]
 //
 //        db.run(assocs.asTry).map {
-//          case Success(r) => r.view.groupBy(_.variantId).mapValues(G2VAssociation(_)).values.toSeq
+//          case Success(r) => r.view.groupBy(_.geneId).mapValues(G2VAssociation(_)).values.toSeq
 //          case Failure(ex) =>
 //            logger.error(ex.getMessage)
 //            Seq.empty

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -8,14 +8,12 @@ import com.sksamuel.elastic4s.{ElasticsearchClientUri, analyzers}
 import models.Entities._
 import models.Functions._
 import models.DNA._
-import models.DNA.Implicits._
 import models.Entities.DBImplicits._
 import models.Entities.ESImplicits._
 import models.Violations.{InputParameterCheckError, RegionViolation, SearchStringViolation, VariantViolation}
 import clickhouse.rep.SeqRep.StrSeqRep
 import com.sksamuel.elastic4s.analyzers._
 import sangria.validation.Violation
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 import scala.concurrent._
@@ -25,9 +23,6 @@ import play.db.NamedDatabase
 import play.api.Logger
 import play.api.Environment
 import java.nio.file.{Path, Paths}
-
-import slick.jdbc.GetResult
-
 
 class Backend @Inject()(@NamedDatabase("default") protected val dbConfigProvider: DatabaseConfigProvider,
                         @NamedDatabase("sumstats") protected val dbConfigProviderSumStats: DatabaseConfigProvider,

--- a/app/models/DNA.scala
+++ b/app/models/DNA.scala
@@ -71,26 +71,26 @@ object DNA {
 
   }
 
-  case class Variant(position: Position, refAllele: String, altAllele: String, rsId: Option[String],
-                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None) {
-    lazy val id: String = List(position.chrId, position.position.toString, refAllele, altAllele)
-      .map(_.toUpperCase)
-      .mkString("_")
-  }
-
-  object Variant {
-    implicit val hasId = HasId[Variant, String](_.id)
-
-    def apply(variantId: String): Either[VariantViolation, Variant] = Variant.apply(variantId, None)
-    def apply(variantId: String, rsId: Option[String]): Either[VariantViolation, Variant] = {
-      variantId.toUpperCase.split("_").toList.filter(_.nonEmpty) match {
-        case List(chr: String, pos: String, ref: String, alt: String) =>
-          Right(Variant(Position(chr, pos.toLong), ref, alt, rsId, None, None))
-        case _ =>
-          Left(VariantViolation(variantId))
-      }
-    }
-  }
+//  case class Variant(position: Position, refAllele: String, altAllele: String, rsId: Option[String],
+//                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None) {
+//    lazy val id: String = List(position.chrId, position.position.toString, refAllele, altAllele)
+//      .map(_.toUpperCase)
+//      .mkString("_")
+//  }
+//
+//  object Variant {
+//    implicit val hasId = HasId[Variant, String](_.id)
+//
+//    def apply(variantId: String): Either[VariantViolation, Variant] = Variant.apply(variantId, None)
+//    def apply(variantId: String, rsId: Option[String]): Either[VariantViolation, Variant] = {
+//      variantId.toUpperCase.split("_").toList.filter(_.nonEmpty) match {
+//        case List(chr: String, pos: String, ref: String, alt: String) =>
+//          Right(Variant(Position(chr, pos.toLong), ref, alt, rsId, None, None))
+//        case _ =>
+//          Left(VariantViolation(variantId))
+//      }
+//    }
+//  }
 
 //  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
 //                  chromosome: Option[String] = None, tss: Option[Long] = None,
@@ -115,13 +115,13 @@ object DNA {
 //  }
 
   object Implicits {
-    implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =
-      Variant.apply(variantID)
-
-    implicit val getVariantFromDB: GetResult[Variant] =
-      GetResult(r => Variant(Position(r.nextString, r.nextLong), refAllele = r.nextString,
-        altAllele = r.nextString, rsId = r.nextStringOption, nearestGeneId = r.nextStringOption,
-        nearestCodingGeneId = r.nextStringOption))
+//    implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =
+//      Variant.apply(variantID)
+//
+//    implicit val getVariantFromDB: GetResult[Variant] =
+//      GetResult(r => Variant(Position(r.nextString, r.nextLong), refAllele = r.nextString,
+//        altAllele = r.nextString, rsId = r.nextStringOption, nearestGeneId = r.nextStringOption,
+//        nearestCodingGeneId = r.nextStringOption))
 
 //    implicit val getGeneFromDB: GetResult[Gene] =
 //      GetResult(r => Gene(id = r.nextString(), symbol = r.nextStringOption(), bioType = r.nextStringOption(),

--- a/app/models/DNA.scala
+++ b/app/models/DNA.scala
@@ -2,8 +2,6 @@ package models
 
 import java.io.FileNotFoundException
 
-import clickhouse.rep.SeqRep.LSeqRep
-import clickhouse.rep.SeqRep.Implicits._
 import models.Violations.{GeneViolation, RegionViolation, VariantViolation}
 import sangria.execution.deferred.HasId
 
@@ -11,7 +9,6 @@ import scala.io.Source
 import slick.jdbc.GetResult
 import kantan.csv._
 import kantan.csv.ops._
-import kantan.csv.generic._
 import play.api.Logger
 
 object DNA {

--- a/app/models/DNA.scala
+++ b/app/models/DNA.scala
@@ -71,26 +71,26 @@ object DNA {
 
   }
 
-//  case class Variant(position: Position, refAllele: String, altAllele: String, rsId: Option[String],
-//                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None) {
-//    lazy val id: String = List(position.chrId, position.position.toString, refAllele, altAllele)
-//      .map(_.toUpperCase)
-//      .mkString("_")
-//  }
-//
-//  object Variant {
-//    implicit val hasId = HasId[Variant, String](_.id)
-//
-//    def apply(variantId: String): Either[VariantViolation, Variant] = Variant.apply(variantId, None)
-//    def apply(variantId: String, rsId: Option[String]): Either[VariantViolation, Variant] = {
-//      variantId.toUpperCase.split("_").toList.filter(_.nonEmpty) match {
-//        case List(chr: String, pos: String, ref: String, alt: String) =>
-//          Right(Variant(Position(chr, pos.toLong), ref, alt, rsId, None, None))
-//        case _ =>
-//          Left(VariantViolation(variantId))
-//      }
-//    }
-//  }
+  case class Variant(position: Position, refAllele: String, altAllele: String, rsId: Option[String],
+                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None) {
+    lazy val id: String = List(position.chrId, position.position.toString, refAllele, altAllele)
+      .map(_.toUpperCase)
+      .mkString("_")
+  }
+
+  object Variant {
+    implicit val hasId = HasId[Variant, String](_.id)
+
+    def apply(variantId: String): Either[VariantViolation, Variant] = Variant.apply(variantId, None)
+    def apply(variantId: String, rsId: Option[String]): Either[VariantViolation, Variant] = {
+      variantId.toUpperCase.split("_").toList.filter(_.nonEmpty) match {
+        case List(chr: String, pos: String, ref: String, alt: String) =>
+          Right(Variant(Position(chr, pos.toLong), ref, alt, rsId, None, None))
+        case _ =>
+          Left(VariantViolation(variantId))
+      }
+    }
+  }
 
 //  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
 //                  chromosome: Option[String] = None, tss: Option[Long] = None,
@@ -115,13 +115,13 @@ object DNA {
 //  }
 
   object Implicits {
-//    implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =
-//      Variant.apply(variantID)
+    implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =
+      Variant.apply(variantID)
 //
-//    implicit val getVariantFromDB: GetResult[Variant] =
-//      GetResult(r => Variant(Position(r.nextString, r.nextLong), refAllele = r.nextString,
-//        altAllele = r.nextString, rsId = r.nextStringOption, nearestGeneId = r.nextStringOption,
-//        nearestCodingGeneId = r.nextStringOption))
+    implicit val getVariantFromDB: GetResult[Variant] =
+      GetResult(r => Variant(Position(r.nextString, r.nextLong), refAllele = r.nextString,
+        altAllele = r.nextString, rsId = r.nextStringOption, nearestGeneId = r.nextStringOption,
+        nearestCodingGeneId = r.nextStringOption))
 
 //    implicit val getGeneFromDB: GetResult[Gene] =
 //      GetResult(r => Gene(id = r.nextString(), symbol = r.nextStringOption(), bioType = r.nextStringOption(),

--- a/app/models/DNA.scala
+++ b/app/models/DNA.scala
@@ -89,27 +89,28 @@ object DNA {
     }
   }
 
-//  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
-//                  chromosome: Option[String] = None, tss: Option[Long] = None,
-//                  bioType: Option[String] = None, fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
-//
-//  object Gene {
-//    /** construct a gene from a gene id symbol. It only supports Ensembl ID at the moment
-//      *
-//      * @param geneId Ensembl Gene ID as "ENSG000000[.123]" and it will strip the version
-//      * @return Either a Gene or a GeneViolation as the gene was not properly specified
-//      */
-//    def apply(geneId: String): Either[GeneViolation, Gene] = {
-//      geneId.toUpperCase.split("\\.").toList.filter(_.nonEmpty) match {
-//        case ensemblId :: _ =>
-//          Right(Gene(ensemblId, None))
-//        case Nil =>
-//          Left(GeneViolation(geneId))
-//      }
-//    }
-//
-//    implicit val hasId = HasId[Gene, String](_.id)
-//  }
+  // NOTE: DNA.Gene is not used, but this is left in for the tests and for reference
+  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
+                  chromosome: Option[String] = None, tss: Option[Long] = None,
+                  bioType: Option[String] = None, fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
+
+  object Gene {
+    /** construct a gene from a gene id symbol. It only supports Ensembl ID at the moment
+      *
+      * @param geneId Ensembl Gene ID as "ENSG000000[.123]" and it will strip the version
+      * @return Either a Gene or a GeneViolation as the gene was not properly specified
+      */
+    def apply(geneId: String): Either[GeneViolation, Gene] = {
+      geneId.toUpperCase.split("\\.").toList.filter(_.nonEmpty) match {
+        case ensemblId :: _ =>
+          Right(Gene(ensemblId, None))
+        case Nil =>
+          Left(GeneViolation(geneId))
+      }
+    }
+
+    implicit val hasId = HasId[Gene, String](_.id)
+  }
 
   object Implicits {
     implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =

--- a/app/models/DNA.scala
+++ b/app/models/DNA.scala
@@ -92,27 +92,27 @@ object DNA {
     }
   }
 
-  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
-                  chromosome: Option[String] = None, tss: Option[Long] = None,
-                  bioType: Option[String] = None, fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
-
-  object Gene {
-    /** construct a gene from a gene id symbol. It only supports Ensembl ID at the moment
-      *
-      * @param geneId Ensembl Gene ID as "ENSG000000[.123]" and it will strip the version
-      * @return Either a Gene or a GeneViolation as the gene was not properly specified
-      */
-    def apply(geneId: String): Either[GeneViolation, Gene] = {
-      geneId.toUpperCase.split("\\.").toList.filter(_.nonEmpty) match {
-        case ensemblId :: _ =>
-          Right(Gene(ensemblId, None))
-        case Nil =>
-          Left(GeneViolation(geneId))
-      }
-    }
-
-    implicit val hasId = HasId[Gene, String](_.id)
-  }
+//  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
+//                  chromosome: Option[String] = None, tss: Option[Long] = None,
+//                  bioType: Option[String] = None, fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
+//
+//  object Gene {
+//    /** construct a gene from a gene id symbol. It only supports Ensembl ID at the moment
+//      *
+//      * @param geneId Ensembl Gene ID as "ENSG000000[.123]" and it will strip the version
+//      * @return Either a Gene or a GeneViolation as the gene was not properly specified
+//      */
+//    def apply(geneId: String): Either[GeneViolation, Gene] = {
+//      geneId.toUpperCase.split("\\.").toList.filter(_.nonEmpty) match {
+//        case ensemblId :: _ =>
+//          Right(Gene(ensemblId, None))
+//        case Nil =>
+//          Left(GeneViolation(geneId))
+//      }
+//    }
+//
+//    implicit val hasId = HasId[Gene, String](_.id)
+//  }
 
   object Implicits {
     implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =
@@ -123,10 +123,10 @@ object DNA {
         altAllele = r.nextString, rsId = r.nextStringOption, nearestGeneId = r.nextStringOption,
         nearestCodingGeneId = r.nextStringOption))
 
-    implicit val getGeneFromDB: GetResult[Gene] =
-      GetResult(r => Gene(id = r.nextString(), symbol = r.nextStringOption(), bioType = r.nextStringOption(),
-        chromosome = r.nextStringOption(), tss = r.nextLongOption(),
-        start = r.nextLongOption(), end = r.nextLongOption(), fwd = r.nextBooleanOption(),
-        exons = LSeqRep(r.nextString())))
+//    implicit val getGeneFromDB: GetResult[Gene] =
+//      GetResult(r => Gene(id = r.nextString(), symbol = r.nextStringOption(), bioType = r.nextStringOption(),
+//        chromosome = r.nextStringOption(), tss = r.nextLongOption(),
+//        start = r.nextLongOption(), end = r.nextLongOption(), fwd = r.nextBooleanOption(),
+//        exons = LSeqRep(r.nextString())))
   }
 }

--- a/app/models/DNA.scala
+++ b/app/models/DNA.scala
@@ -68,63 +68,69 @@ object DNA {
 
   }
 
-  case class Variant(position: Position, refAllele: String, altAllele: String, rsId: Option[String],
-                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None) {
-    lazy val id: String = List(position.chrId, position.position.toString, refAllele, altAllele)
+  case class Variant(chromosome: String, position: Long, refAllele: String, altAllele: String,
+                     rsId: Option[String], nearestGeneId: Option[String] = None,
+                     nearestCodingGeneId: Option[String] = None) {
+    lazy val id: String = List(chromosome, position.toString, refAllele, altAllele)
       .map(_.toUpperCase)
       .mkString("_")
   }
 
-  object Variant {
-    implicit val hasId = HasId[Variant, String](_.id)
+  // id, chromosome, position, refAllele, altAllele, rsId, nearestGeneId, nearestCodingGeneId
 
-    def apply(variantId: String): Either[VariantViolation, Variant] = Variant.apply(variantId, None)
-    def apply(variantId: String, rsId: Option[String]): Either[VariantViolation, Variant] = {
+  object Variant extends ((String, String, Long, String, String, Option[String], Option[String],
+    Option[String]) => Variant) {
+    private[this] def parseVariant(variantId: String, rsId: Option[String]): Option[Variant] = {
       variantId.toUpperCase.split("_").toList.filter(_.nonEmpty) match {
         case List(chr: String, pos: String, ref: String, alt: String) =>
-          Right(Variant(Position(chr, pos.toLong), ref, alt, rsId, None, None))
-        case _ =>
-          Left(VariantViolation(variantId))
+          Some(Variant(chr, pos.toLong, ref, alt, rsId, None, None))
+        case _ => None
       }
     }
+
+    def apply(variantId: String, chromosome: String, position: Long, refAllele: String, altAllele: String,
+              rsId: Option[String], nearestGeneId: Option[String],
+              nearestCodingGeneId: Option[String]): Variant =
+      Variant(chromosome, position, refAllele, altAllele, rsId, nearestGeneId, nearestCodingGeneId)
+
+    def apply(variantId: String): Either[VariantViolation, Variant] = apply(variantId, None)
+
+    def apply(variantId: String, rsId: Option[String]): Either[VariantViolation, Variant] = {
+      val pv = parseVariant(variantId, rsId)
+      Either.cond(pv.isDefined, pv.get, VariantViolation(variantId))
+    }
+
+    def unapply(v: Variant): Option[(String, String, Long, String, String,
+      Option[String], Option[String], Option[String])] = Some(v.id, v.chromosome, v.position, v.refAllele,
+        v.altAllele, v.rsId, v.nearestGeneId, v.nearestCodingGeneId)
   }
 
-  // NOTE: DNA.Gene is not used, but this is left in for the tests and for reference
-  case class Gene(id: String, symbol: Option[String], start: Option[Long] = None, end: Option[Long] = None,
-                  chromosome: Option[String] = None, tss: Option[Long] = None,
-                  bioType: Option[String] = None, fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
+  case class Gene(id: String, symbol: Option[String], bioType: Option[String] = None, chromosome: Option[String] = None,
+                  tss: Option[Long] = None, start: Option[Long] = None, end: Option[Long] = None,
+                  fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
 
-  object Gene {
+  object Gene extends ((String, Option[String], Option[String], Option[String], Option[Long],
+    Option[Long], Option[Long], Option[Boolean], Seq[Long]) => Gene) {
+    private[this] def parseGene(geneId: String, symbol : Option[String]): Option[Gene] = {
+      geneId.toUpperCase.split("\\.").toList.filter(_.nonEmpty) match {
+        case ensemblId :: _ =>
+          Some(Gene(ensemblId, symbol))
+        case Nil => None
+      }
+    }
+
     /** construct a gene from a gene id symbol. It only supports Ensembl ID at the moment
       *
       * @param geneId Ensembl Gene ID as "ENSG000000[.123]" and it will strip the version
       * @return Either a Gene or a GeneViolation as the gene was not properly specified
       */
     def apply(geneId: String): Either[GeneViolation, Gene] = {
-      geneId.toUpperCase.split("\\.").toList.filter(_.nonEmpty) match {
-        case ensemblId :: _ =>
-          Right(Gene(ensemblId, None))
-        case Nil =>
-          Left(GeneViolation(geneId))
-      }
+      val pg = parseGene(geneId, None)
+      Either.cond(pg.isDefined, pg.get, GeneViolation(geneId))
     }
 
-    implicit val hasId = HasId[Gene, String](_.id)
-  }
-
-  object Implicits {
-    implicit def stringToVariant(variantID: String): Either[VariantViolation, Variant] =
-      Variant.apply(variantID)
-//
-    implicit val getVariantFromDB: GetResult[Variant] =
-      GetResult(r => Variant(Position(r.nextString, r.nextLong), refAllele = r.nextString,
-        altAllele = r.nextString, rsId = r.nextStringOption, nearestGeneId = r.nextStringOption,
-        nearestCodingGeneId = r.nextStringOption))
-
-//    implicit val getGeneFromDB: GetResult[Gene] =
-//      GetResult(r => Gene(id = r.nextString(), symbol = r.nextStringOption(), bioType = r.nextStringOption(),
-//        chromosome = r.nextStringOption(), tss = r.nextLongOption(),
-//        start = r.nextLongOption(), end = r.nextLongOption(), fwd = r.nextBooleanOption(),
-//        exons = LSeqRep(r.nextString())))
+    def unapply(gene: Gene): Option[(String, Option[String], Option[String], Option[String], Option[Long],
+      Option[Long], Option[Long], Option[Boolean], Seq[Long])] = Some(gene.id, gene.symbol, gene.bioType,
+        gene.chromosome, gene.tss, gene.start, gene.end, gene.fwd, gene.exons)
   }
 }

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -9,8 +9,12 @@ import sangria.execution.deferred.HasId
 import clickhouse.rep.SeqRep._
 import clickhouse.rep.SeqRep.Implicits._
 
-object Entities {
 
+
+
+object Entities {
+  implicit val variantHasId = HasId[FRM.Variant, String](_.id)
+  implicit val studyHasId = HasId[FRM.Study, String](_.studyId)
 
 //  case class OverlapRow(stid: String, numOverlapLoci: Int)
 //
@@ -37,23 +41,23 @@ object Entities {
                                    sas1000GProp: Option[Double],
                                    log10Abf: Option[Double],
                                    posteriorProbability: Option[Double])
-//
-//
-//  case class IndexVariantTable(associations: Vector[IndexVariantAssociation])
-//
-//  case class IndexVariantAssociation(tagVariant: Variant,
-//                                     studyId: String,
-//                                     pval: Double,
-//                                     nTotal: Int, // n_initial + n_replication which could be null as well both fields
-//                                     nCases: Int,
-//                                     r2: Option[Double],
-//                                     afr1000GProp: Option[Double],
-//                                     amr1000GProp: Option[Double],
-//                                     eas1000GProp: Option[Double],
-//                                     eur1000GProp: Option[Double],
-//                                     sas1000GProp: Option[Double],
-//                                     log10Abf: Option[Double],
-//                                     posteriorProbability: Option[Double])
+
+
+  case class IndexVariantTable(associations: Seq[IndexVariantAssociation])
+
+  case class IndexVariantAssociation(tagVariant: FRM.Variant,
+                                     studyId: String,
+                                     pval: Double,
+                                     nTotal: Int, // n_initial + n_replication which could be null as well both fields
+                                     nCases: Int,
+                                     r2: Option[Double],
+                                     afr1000GProp: Option[Double],
+                                     amr1000GProp: Option[Double],
+                                     eas1000GProp: Option[Double],
+                                     eur1000GProp: Option[Double],
+                                     sas1000GProp: Option[Double],
+                                     log10Abf: Option[Double],
+                                     posteriorProbability: Option[Double])
 //
 //  case class ManhattanTable(studyId: String, associations: Vector[ManhattanAssociation])
 //

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -12,115 +12,119 @@ import clickhouse.rep.SeqRep.Implicits._
 object Entities {
 
 
-  case class OverlapRow(stid: String, numOverlapLoci: Int)
-  case class OverlappedLociStudy(studyId: String, topOverlappedStudies: IndexedSeq[OverlapRow])
+//  case class OverlapRow(stid: String, numOverlapLoci: Int)
+//
+//  case class OverlappedLociStudy(studyId: String, topOverlappedStudies: IndexedSeq[OverlapRow])
+//
+//  case class OverlappedVariantsStudy(studyId: String, overlaps: Seq[OverlappedVariant])
+//
+//  case class OverlappedVariant(variantIdA: String, variantIdB: String, overlapAB: Int,
+//                               distinctA: Int, distinctB: Int)
+//
+//
+//  case class TagVariantTable(associations: Vector[TagVariantAssociation])
+//
+//  case class TagVariantAssociation(indexVariant: Variant,
+//                                   studyId: String,
+//                                   pval: Double,
+//                                   nTotal: Int, // n_initial + n_replication which could be null as well both fields
+//                                   nCases: Int,
+//                                   r2: Option[Double],
+//                                   afr1000GProp: Option[Double],
+//                                   amr1000GProp: Option[Double],
+//                                   eas1000GProp: Option[Double],
+//                                   eur1000GProp: Option[Double],
+//                                   sas1000GProp: Option[Double],
+//                                   log10Abf: Option[Double],
+//                                   posteriorProbability: Option[Double])
+//
+//
+//  case class IndexVariantTable(associations: Vector[IndexVariantAssociation])
+//
+//  case class IndexVariantAssociation(tagVariant: Variant,
+//                                     studyId: String,
+//                                     pval: Double,
+//                                     nTotal: Int, // n_initial + n_replication which could be null as well both fields
+//                                     nCases: Int,
+//                                     r2: Option[Double],
+//                                     afr1000GProp: Option[Double],
+//                                     amr1000GProp: Option[Double],
+//                                     eas1000GProp: Option[Double],
+//                                     eur1000GProp: Option[Double],
+//                                     sas1000GProp: Option[Double],
+//                                     log10Abf: Option[Double],
+//                                     posteriorProbability: Option[Double])
+//
+//  case class ManhattanTable(studyId: String, associations: Vector[ManhattanAssociation])
+//
+//  case class ManhattanAssociation(variantId: String, pval: Double,
+//                                  bestGenes: Seq[(String, Double)], crediblbeSetSize: Option[Long],
+//                                  ldSetSize: Option[Long], totalSetSize: Long)
+//
+//  case class V2DByStudy(index_variant_id: String, pval: Double,
+//                        credibleSetSize: Option[Long], ldSetSize: Option[Long], totalSetSize: Long, topGenes: Seq[(String, Double)])
 
-  case class OverlappedVariantsStudy(studyId: String, overlaps: Seq[OverlappedVariant])
-  case class OverlappedVariant(variantIdA: String, variantIdB: String, overlapAB: Int,
-                               distinctA: Int, distinctB: Int)
+  //  case class StudyInfo(study: Option[Study])
+  //
+  //  object Study {
+  //    implicit val hasId = HasId[Study, String](_.studyId)
+  //  }
+  //
+  //  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
+  //                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
+  //                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
+  //                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
+  //                   traitCategory: Option[String])
 
+  //  case class PheWASTable(associations: Vector[VariantPheWAS])
+  //  case class VariantPheWAS(stid: String, pval: Double, beta: Double, se: Double, eaf: Double, maf: Double,
+  //                           nSamplesVariant: Option[Long], nSamplesStudy: Option[Long], nCasesStudy: Option[Long],
+  //                           nCasesVariant: Option[Long], oddRatio: Option[Double], chip: String, info: Option[Double])
+  //
+  //  case class GeneTagVariant(geneId: String, tagVariantId: String, overallScore: Double)
+  //  case class TagVariantIndexVariantStudy(tagVariantId: String, indexVariantId: String, studyId: String,
+  //                                         r2: Option[Double], pval: Double, posteriorProb: Option[Double])
+  //  case class Gecko(geneIds: Seq[String], tagVariants: Seq[Variant], indexVariants: Seq[Variant],
+  //                   studies: Seq[String], geneTagVariants: Seq[GeneTagVariant],
+  //                   tagVariantIndexVariantStudies: Seq[TagVariantIndexVariantStudy])
+  //  case class GeckoLine(geneId: String, tagVariant: Variant, indexVariant: Variant, studyId: String,
+  //                       geneTagVariant: GeneTagVariant, tagVariantIndexVariantStudy: TagVariantIndexVariantStudy)
 
+  //  object Gecko {
+  //    def apply(geckoLines: Seq[GeckoLine], geneIdsInLoci: Set[String] = Set.empty): Option[Gecko] = {
+  //      if (geckoLines.isEmpty)
+  //        Some(Gecko(Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty))
+  //      else {
+  //        var geneIds: Set[String] = Set.empty
+  //        var tagVariants: Set[Variant] = Set.empty
+  //        var indexVariants: Set[Variant] = Set.empty
+  //        var studies: Set[String] = Set.empty
+  //        var tagVariantIndexVariantStudies: Set[TagVariantIndexVariantStudy] = Set.empty
+  //        var geneTagVariants: Set[GeneTagVariant] = Set.empty
+  //
+  //        geckoLines.foreach(line => {
+  //          geneIds += line.geneId
+  //          tagVariants += line.tagVariant
+  //          indexVariants += line.indexVariant
+  //          studies += line.studyId
+  //          geneTagVariants += line.geneTagVariant
+  //          tagVariantIndexVariantStudies += line.tagVariantIndexVariantStudy
+  //        })
+  //
+  //        // breakOut could be a good way to map virtually to a other collection of a different type
+  //        // https://stackoverflow.com/questions/46509951/how-do-i-efficiently-count-distinct-fields-in-a-collection
+  //        // val genes = geckoLines.map(_.gene)(breakOut).toSet.toSeq
+  //         Some(Gecko((geneIds union geneIdsInLoci).toSeq, tagVariants.toSeq, indexVariants.toSeq, studies.toSeq,
+  //                  geneTagVariants.toSeq, tagVariantIndexVariantStudies.toSeq))
+  //      }
+  //    }
+  //  }
 
-  case class TagVariantTable(associations: Vector[TagVariantAssociation])
-  case class TagVariantAssociation(indexVariant: Variant,
-                                     studyId: String,
-                                     pval: Double,
-                                     nTotal: Int, // n_initial + n_replication which could be null as well both fields
-                                     nCases: Int,
-                                     r2: Option[Double],
-                                     afr1000GProp: Option[Double],
-                                     amr1000GProp: Option[Double],
-                                     eas1000GProp: Option[Double],
-                                     eur1000GProp: Option[Double],
-                                     sas1000GProp: Option[Double],
-                                     log10Abf: Option[Double],
-                                     posteriorProbability: Option[Double])
+  //  case class VariantSearchResult (variant: Variant)
 
-
-  case class IndexVariantTable(associations: Vector[IndexVariantAssociation])
-  case class IndexVariantAssociation(tagVariant: Variant,
-                                     studyId: String,
-                                     pval: Double,
-                                     nTotal: Int, // n_initial + n_replication which could be null as well both fields
-                                     nCases: Int,
-                                     r2: Option[Double],
-                                     afr1000GProp: Option[Double],
-                                     amr1000GProp: Option[Double],
-                                     eas1000GProp: Option[Double],
-                                     eur1000GProp: Option[Double],
-                                     sas1000GProp: Option[Double],
-                                     log10Abf: Option[Double],
-                                     posteriorProbability: Option[Double])
-
-  case class ManhattanTable(studyId: String, associations: Vector[ManhattanAssociation])
-  case class ManhattanAssociation(variantId: String, pval: Double,
-                                  bestGenes: Seq[(String, Double)], crediblbeSetSize: Option[Long],
-                                  ldSetSize: Option[Long], totalSetSize: Long)
-
-  case class V2DByStudy(index_variant_id: String, pval: Double,
-                        credibleSetSize: Option[Long], ldSetSize: Option[Long], totalSetSize: Long, topGenes: Seq[(String, Double)])
-
-  case class StudyInfo(study: Option[Study])
-
-  object Study {
-    implicit val hasId = HasId[Study, String](_.studyId)
-  }
-
-  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
-                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
-                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
-                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
-                   traitCategory: Option[String])
-
-  case class PheWASTable(associations: Vector[VariantPheWAS])
-  case class VariantPheWAS(stid: String, pval: Double, beta: Double, se: Double, eaf: Double, maf: Double,
-                           nSamplesVariant: Option[Long], nSamplesStudy: Option[Long], nCasesStudy: Option[Long],
-                           nCasesVariant: Option[Long], oddRatio: Option[Double], chip: String, info: Option[Double])
-
-  case class GeneTagVariant(geneId: String, tagVariantId: String, overallScore: Double)
-  case class TagVariantIndexVariantStudy(tagVariantId: String, indexVariantId: String, studyId: String,
-                                         r2: Option[Double], pval: Double, posteriorProb: Option[Double])
-  case class Gecko(geneIds: Seq[String], tagVariants: Seq[Variant], indexVariants: Seq[Variant],
-                   studies: Seq[String], geneTagVariants: Seq[GeneTagVariant],
-                   tagVariantIndexVariantStudies: Seq[TagVariantIndexVariantStudy])
-  case class GeckoLine(geneId: String, tagVariant: Variant, indexVariant: Variant, studyId: String,
-                       geneTagVariant: GeneTagVariant, tagVariantIndexVariantStudy: TagVariantIndexVariantStudy)
-
-  object Gecko {
-    def apply(geckoLines: Seq[GeckoLine], geneIdsInLoci: Set[String] = Set.empty): Option[Gecko] = {
-      if (geckoLines.isEmpty)
-        Some(Gecko(Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty))
-      else {
-        var geneIds: Set[String] = Set.empty
-        var tagVariants: Set[Variant] = Set.empty
-        var indexVariants: Set[Variant] = Set.empty
-        var studies: Set[String] = Set.empty
-        var tagVariantIndexVariantStudies: Set[TagVariantIndexVariantStudy] = Set.empty
-        var geneTagVariants: Set[GeneTagVariant] = Set.empty
-
-        geckoLines.foreach(line => {
-          geneIds += line.geneId
-          tagVariants += line.tagVariant
-          indexVariants += line.indexVariant
-          studies += line.studyId
-          geneTagVariants += line.geneTagVariant
-          tagVariantIndexVariantStudies += line.tagVariantIndexVariantStudy
-        })
-
-        // breakOut could be a good way to map virtually to a other collection of a different type
-        // https://stackoverflow.com/questions/46509951/how-do-i-efficiently-count-distinct-fields-in-a-collection
-        // val genes = geckoLines.map(_.gene)(breakOut).toSet.toSeq
-         Some(Gecko((geneIds union geneIdsInLoci).toSeq, tagVariants.toSeq, indexVariants.toSeq, studies.toSeq,
-                  geneTagVariants.toSeq, tagVariantIndexVariantStudies.toSeq))
-      }
-    }
-  }
-
-  case class VariantSearchResult (variant: Variant)
-
-  case class SearchResultSet(totalGenes: Long, genes: Seq[FRM.Gene],
-                             totalVariants: Long, variants: Seq[VariantSearchResult],
-                             totalStudies: Long, studies: Seq[Study])
+  //  case class SearchResultSet(totalGenes: Long, genes: Seq[FRM.Gene],
+  //                             totalVariants: Long, variants: Seq[VariantSearchResult],
+  //                             totalStudies: Long, studies: Seq[FRM.Study])
 
   case class Tissue(id: String) {
     lazy val name: Option[String] = Option(id.replace("_", " ").toLowerCase.capitalize)
@@ -182,7 +186,9 @@ object Entities {
                            tissues: Seq[T])
 
   case class QTLTissue(tissue: Tissue, quantile: Double, beta: Option[Double], pval: Option[Double])
+
   case class IntervalTissue(tissue: Tissue, quantile: Double, score: Option[Double])
+
   case class FPredTissue(tissue: Tissue, maxEffectLabel: Option[String], maxEffectScore: Option[Double])
 
   case class ScoredG2VLine(geneId: String, variantId: String, overallScore: Double, sourceScores: Map[String, Double],
@@ -192,154 +198,170 @@ object Entities {
                            intervalScoreQ: Double)
 
   object ESImplicits {
-    implicit object GeneHitReader extends HitReader[FRM.Gene] {
-      override def read(hit: Hit): Either[Throwable, FRM.Gene] = {
-        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
-        else {
-          val mv = hit.sourceAsMap
 
-          Right(FRM.Gene(mv("gene_id").toString,
-            Option(mv("gene_name").asInstanceOf[String]),
-            Option(mv("biotype").asInstanceOf[String]),
-            Option(mv("chr").toString),
-            Option(mv("start").asInstanceOf[Int]),
-            Option(mv("end").asInstanceOf[Int]),
-            Option(mv("tss").asInstanceOf[Int]),
-            Option(mv("fwdstrand").asInstanceOf[Int] match {
-              case 0 => false
-              case 1 => true
-              case _ => false
-            }),
-            Seq.empty
-          )
-          )
-
+//    implicit object GeneHitReader extends HitReader[FRM.Gene] {
+//      override def read(hit: Hit): Either[Throwable, FRM.Gene] = {
+//        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
+//        else {
+//          val mv = hit.sourceAsMap
+//
 //          Right(FRM.Gene(mv("gene_id").toString,
 //            Option(mv("gene_name").asInstanceOf[String]),
+//            Option(mv("biotype").asInstanceOf[String]),
+//            Option(mv("chr").toString),
 //            Option(mv("start").asInstanceOf[Int]),
 //            Option(mv("end").asInstanceOf[Int]),
-//            Option(mv("chr").toString),
 //            Option(mv("tss").asInstanceOf[Int]),
-//            Option(mv("biotype").asInstanceOf[String]),
 //            Option(mv("fwdstrand").asInstanceOf[Int] match {
 //              case 0 => false
 //              case 1 => true
 //              case _ => false
-//            })
-//            )
+//            }),
+//            Seq.empty
 //          )
-        }
+//          )
+//
+//          //          Right(FRM.Gene(mv("gene_id").toString,
+//          //            Option(mv("gene_name").asInstanceOf[String]),
+//          //            Option(mv("start").asInstanceOf[Int]),
+//          //            Option(mv("end").asInstanceOf[Int]),
+//          //            Option(mv("chr").toString),
+//          //            Option(mv("tss").asInstanceOf[Int]),
+//          //            Option(mv("biotype").asInstanceOf[String]),
+//          //            Option(mv("fwdstrand").asInstanceOf[Int] match {
+//          //              case 0 => false
+//          //              case 1 => true
+//          //              case _ => false
+//          //            })
+//          //            )
+//          //          )
+//        }
+//      }
+//    }
+
+    //    implicit object VariantHitReader extends HitReader[VariantSearchResult] {
+    //      override def read(hit: Hit): Either[Throwable, VariantSearchResult] = {
+    //        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
+    //        else {
+    //          val mv = hit.sourceAsMap
+    //
+    //          val variant = Variant(Position(mv("chr_id").toString, mv("position").asInstanceOf[Int]),
+    //            mv("ref_allele").toString, mv("alt_allele").toString, Option(mv("rs_id").toString))
+    //
+    //          Right(VariantSearchResult(variant))
+    //        }
+    //      }
+    //    }
+
+    //    implicit object StudyHitReader extends HitReader[FRM.Study] {
+    //      override def read(hit: Hit): Either[Throwable, FRM.Study] = {
+    //        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
+    //        else {
+    //          val mv = hit.sourceAsMap
+    //
+    //          Right(FRM.Study(mv("study_id").toString,
+    //            mv.get("trait_code").map(_.toString).get,
+    //            mv.get("trait_reported").map(_.toString).get,
+    //            mv.get("trait_efos").map(_.asInstanceOf[Seq[String]]).get,
+    //            mv.get("pmid").map(_.asInstanceOf[String]),
+    //            mv.get("pub_date").map(_.asInstanceOf[String]),
+    //            mv.get("pub_journal").map(_.asInstanceOf[String]),
+    //            mv.get("pub_title").map(_.asInstanceOf[String]),
+    //            mv.get("pub_author").map(_.asInstanceOf[String]),
+    //            mv.get("ancestry_initial").map(_.asInstanceOf[Seq[String]]).get,
+    //            mv.get("ancestry_replication").map(_.asInstanceOf[Seq[String]]).get,
+    //            mv.get("n_initial").map(_.asInstanceOf[Int].toLong),
+    //            mv.get("n_replication").map(_.asInstanceOf[Int].toLong),
+    //            mv.get("n_cases").map(_.asInstanceOf[Int].toLong),
+    //            mv.get("trait_category").map(_.asInstanceOf[String]))
+    //          )
+    //        }
+    //      }
+    //    }
       }
+
+    object DBImplicits {
+//      implicit val getV2DByStudy: GetResult[V2DByStudy] = {
+//        def toGeneScoreTuple(geneIds: Seq[String], geneScores: Seq[Double]): Seq[(String, Double)] = {
+//          val ordScored = (geneIds zip geneScores)
+//            .sortBy(_._2)(Ordering[Double].reverse)
+//
+//          if (ordScored.isEmpty) ordScored
+//          else {
+//            ordScored.takeWhile(_._2 == ordScored.head._2)
+//          }
+//        }
+//
+//        GetResult(r => V2DByStudy(r.<<, r.<<, r.<<?, r.<<?, r.<<,
+//          toGeneScoreTuple(StrSeqRep(r.<<), DSeqRep(r.<<))))
+//      }
+
+      //    implicit val getSumStatsByVariantPheWAS: GetResult[VariantPheWAS] =
+      //      GetResult(r => VariantPheWAS(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<,
+      //        r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<?))
+
+      //    implicit val getStudy: GetResult[Study] =
+      //      GetResult(r => Study(r.<<, r.<<, r.<<, StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?, r.<<?,
+      //        StrSeqRep(r.<<), StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?))
+
+      //    implicit val getIndexVariantAssoc: GetResult[IndexVariantAssociation] = GetResult(
+      //      r => {
+      //        val variant = Variant(r.<<, r.<<?)
+      //        IndexVariantAssociation(variant.right.get, r.<<,
+      //          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
+      //      }
+      //    )
+
+      //    implicit val getTagVariantAssoc: GetResult[TagVariantAssociation] = GetResult(
+      //      r => {
+      //        val variant = Variant(r.<<, r.<<?)
+      //        TagVariantAssociation(variant.right.get, r.<<,
+      //          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
+      //      }
+      //    )
+
+      //    implicit val getGeckoLine: GetResult[GeckoLine] = GetResult(
+      //      r => {
+      //        val tagVariant = Variant(r.<<, r.<<?).right.get
+      //        val indexVariant = Variant(r.<<, r.<<?).right.get
+      //
+      //        val geneId = r.nextString()
+      //        val studyId: String = r.<<
+      //
+      //        val r2 = r.nextDoubleOption()
+      //        val posteriorProb = r.nextDoubleOption()
+      //        val pval = r.nextDouble()
+      //        val overallScore = r.nextDouble()
+      //
+      //        val geneTagVariant = GeneTagVariant(geneId, tagVariant.id, overallScore)
+      //        val tagVariantIndexVariantStudy = TagVariantIndexVariantStudy(tagVariant.id, indexVariant.id,
+      //          studyId, r2, pval, posteriorProb)
+      //
+      //        GeckoLine(geneId, tagVariant, indexVariant, studyId, geneTagVariant, tagVariantIndexVariantStudy)
+      //      }
+      //    )
+
+//      implicit val getScoredG2VLine: GetResult[ScoredG2VLine] = GetResult(
+//        r => {
+//          ScoredG2VLine(r.<<, r.<<, r.<<,
+//            (StrSeqRep(r.nextString()).rep zip DSeqRep(r.nextString()).rep).toMap,
+//            r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<)
+//        }
+//      )
+
+      //    implicit def frm2gqlVariant = (frm: FRM.Variant) => Variant(variantId=frm.id, rsId = frm.rsId)
+
+      //implicit def frm2gqlVariant(frm: FRM.Variant): DNA.Variant = DNA.Variant(
+      //  position=Position(frm.chromosome, frm.position),
+      //  refAllele=frm.refAllele,
+      //  altAllele=frm.altAllele,
+      //  rsId=frm.rsId,
+      //  nearestGeneId=frm.nearestGeneId,
+      //  nearestCodingGeneId=frm.nearestCodingGeneId
+      //)
+
+      //    implicit val frm2gqlVariant: DNA.Variant = DNA.Variant(variantId=frm.id, rsId = frm.rsId)
     }
 
-    implicit object VariantHitReader extends HitReader[VariantSearchResult] {
-      override def read(hit: Hit): Either[Throwable, VariantSearchResult] = {
-        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
-        else {
-          val mv = hit.sourceAsMap
-
-          val variant = Variant(Position(mv("chr_id").toString, mv("position").asInstanceOf[Int]),
-            mv("ref_allele").toString, mv("alt_allele").toString, Option(mv("rs_id").toString))
-
-          Right(VariantSearchResult(variant))
-        }
-      }
-    }
-
-    implicit object StudyHitReader extends HitReader[Study] {
-      override def read(hit: Hit): Either[Throwable, Study] = {
-        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
-        else {
-          val mv = hit.sourceAsMap
-
-          Right(Study(mv("study_id").toString,
-            mv.get("trait_code").map(_.toString).get,
-            mv.get("trait_reported").map(_.toString).get,
-            mv.get("trait_efos").map(_.asInstanceOf[Seq[String]]).get,
-            mv.get("pmid").map(_.asInstanceOf[String]),
-            mv.get("pub_date").map(_.asInstanceOf[String]),
-            mv.get("pub_journal").map(_.asInstanceOf[String]),
-            mv.get("pub_title").map(_.asInstanceOf[String]),
-            mv.get("pub_author").map(_.asInstanceOf[String]),
-            mv.get("ancestry_initial").map(_.asInstanceOf[Seq[String]]).get,
-            mv.get("ancestry_replication").map(_.asInstanceOf[Seq[String]]).get,
-            mv.get("n_initial").map(_.asInstanceOf[Int].toLong),
-            mv.get("n_replication").map(_.asInstanceOf[Int].toLong),
-            mv.get("n_cases").map(_.asInstanceOf[Int].toLong),
-            mv.get("trait_category").map(_.asInstanceOf[String]))
-          )
-        }
-      }
-    }
   }
 
-  object DBImplicits {
-    implicit val getV2DByStudy: GetResult[V2DByStudy] = {
-      def toGeneScoreTuple(geneIds: Seq[String], geneScores: Seq[Double]): Seq[(String, Double)] = {
-        val ordScored = (geneIds zip geneScores)
-          .sortBy(_._2)(Ordering[Double].reverse)
-
-        if (ordScored.isEmpty) ordScored
-        else {
-          ordScored.takeWhile(_._2 == ordScored.head._2)
-        }
-      }
-
-      GetResult(r => V2DByStudy(r.<<, r.<<, r.<<?, r.<<?, r.<<,
-        toGeneScoreTuple(StrSeqRep(r.<<), DSeqRep(r.<<))))
-    }
-
-    implicit val getSumStatsByVariantPheWAS: GetResult[VariantPheWAS] =
-      GetResult(r => VariantPheWAS(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<,
-        r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<?))
-
-    implicit val getStudy: GetResult[Study] =
-      GetResult(r => Study(r.<<, r.<<, r.<<, StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?, r.<<?,
-        StrSeqRep(r.<<), StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?))
-
-    implicit val getIndexVariantAssoc: GetResult[IndexVariantAssociation] = GetResult(
-      r => {
-        val variant = Variant(r.<<, r.<<?)
-        IndexVariantAssociation(variant.right.get, r.<<,
-          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
-      }
-    )
-
-    implicit val getTagVariantAssoc: GetResult[TagVariantAssociation] = GetResult(
-      r => {
-        val variant = Variant(r.<<, r.<<?)
-        TagVariantAssociation(variant.right.get, r.<<,
-          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
-      }
-    )
-
-    implicit val getGeckoLine: GetResult[GeckoLine] = GetResult(
-      r => {
-        val tagVariant = Variant(r.<<, r.<<?).right.get
-        val indexVariant = Variant(r.<<, r.<<?).right.get
-
-        val geneId = r.nextString()
-        val studyId: String = r.<<
-
-        val r2 = r.nextDoubleOption()
-        val posteriorProb = r.nextDoubleOption()
-        val pval = r.nextDouble()
-        val overallScore = r.nextDouble()
-
-        val geneTagVariant = GeneTagVariant(geneId, tagVariant.id, overallScore)
-        val tagVariantIndexVariantStudy = TagVariantIndexVariantStudy(tagVariant.id, indexVariant.id,
-          studyId, r2, pval, posteriorProb)
-
-        GeckoLine(geneId, tagVariant, indexVariant, studyId, geneTagVariant, tagVariantIndexVariantStudy)
-      }
-    )
-
-    implicit val getScoredG2VLine: GetResult[ScoredG2VLine] = GetResult(
-      r => {
-        ScoredG2VLine(r.<<, r.<<, r.<<,
-          (StrSeqRep(r.nextString()).rep zip DSeqRep(r.nextString()).rep).toMap,
-          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<)
-      }
-    )
-  }
-}

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -116,8 +116,6 @@ object Entities {
     }
   }
 
-  case class GeneSearchResult (gene: Gene)
-
   case class VariantSearchResult (variant: Variant)
 
   case class SearchResultSet(totalGenes: Long, genes: Seq[FRM.Gene],

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -2,20 +2,13 @@ package models
 
 import com.sksamuel.elastic4s.{Hit, HitReader}
 import slick.jdbc.GetResult
-import models.Violations._
 import models.Functions._
 import models.DNA._
 import sangria.execution.deferred.HasId
 import clickhouse.rep.SeqRep._
 import clickhouse.rep.SeqRep.Implicits._
 
-
-
-
 object Entities {
-  implicit val variantHasId = HasId[FRM.Variant, String](_.id)
-  implicit val studyHasId = HasId[FRM.Study, String](_.studyId)
-
   case class OverlapRow(stid: String, numOverlapLoci: Int)
 
   case class OverlappedLociStudy(studyId: String, topOverlappedStudies: IndexedSeq[OverlapRow])
@@ -223,21 +216,6 @@ object Entities {
             Seq.empty
           )
           )
-
-          //          Right(FRM.Gene(mv("gene_id").toString,
-          //            Option(mv("gene_name").asInstanceOf[String]),
-          //            Option(mv("start").asInstanceOf[Int]),
-          //            Option(mv("end").asInstanceOf[Int]),
-          //            Option(mv("chr").toString),
-          //            Option(mv("tss").asInstanceOf[Int]),
-          //            Option(mv("biotype").asInstanceOf[String]),
-          //            Option(mv("fwdstrand").asInstanceOf[Int] match {
-          //              case 0 => false
-          //              case 1 => true
-          //              case _ => false
-          //            })
-          //            )
-          //          )
         }
       }
     }

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -116,9 +116,11 @@ object Entities {
     }
   }
 
+  case class GeneSearchResult (gene: Gene)
+
   case class VariantSearchResult (variant: Variant)
 
-  case class SearchResultSet(totalGenes: Long, genes: Seq[Gene],
+  case class SearchResultSet(totalGenes: Long, genes: Seq[FRM.Gene],
                              totalVariants: Long, variants: Seq[VariantSearchResult],
                              totalStudies: Long, studies: Seq[Study])
 
@@ -192,26 +194,42 @@ object Entities {
                            intervalScoreQ: Double)
 
   object ESImplicits {
-    implicit object GeneHitReader extends HitReader[Gene] {
-      override def read(hit: Hit): Either[Throwable, Gene] = {
+    implicit object GeneHitReader extends HitReader[FRM.Gene] {
+      override def read(hit: Hit): Either[Throwable, FRM.Gene] = {
         if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
         else {
           val mv = hit.sourceAsMap
 
-          Right(Gene(mv("gene_id").toString,
+          Right(FRM.Gene(mv("gene_id").toString,
             Option(mv("gene_name").asInstanceOf[String]),
+            Option(mv("biotype").asInstanceOf[String]),
+            Option(mv("chr").toString),
             Option(mv("start").asInstanceOf[Int]),
             Option(mv("end").asInstanceOf[Int]),
-            Option(mv("chr").toString),
             Option(mv("tss").asInstanceOf[Int]),
-            Option(mv("biotype").asInstanceOf[String]),
             Option(mv("fwdstrand").asInstanceOf[Int] match {
               case 0 => false
               case 1 => true
               case _ => false
-            })
-            )
+            }),
+            None
           )
+          )
+
+//          Right(FRM.Gene(mv("gene_id").toString,
+//            Option(mv("gene_name").asInstanceOf[String]),
+//            Option(mv("start").asInstanceOf[Int]),
+//            Option(mv("end").asInstanceOf[Int]),
+//            Option(mv("chr").toString),
+//            Option(mv("tss").asInstanceOf[Int]),
+//            Option(mv("biotype").asInstanceOf[String]),
+//            Option(mv("fwdstrand").asInstanceOf[Int] match {
+//              case 0 => false
+//              case 1 => true
+//              case _ => false
+//            })
+//            )
+//          )
         }
       }
     }

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -25,10 +25,9 @@ object Entities {
 //  case class OverlappedVariant(variantIdA: String, variantIdB: String, overlapAB: Int,
 //                               distinctA: Int, distinctB: Int)
 //
-//
   case class TagVariantTable(associations: Seq[TagVariantAssociation])
 
-  case class TagVariantAssociation(indexVariant: FRM.Variant,
+  case class TagVariantAssociation(indexVariant: DNA.Variant,
                                    studyId: String,
                                    pval: Double,
                                    nTotal: Int, // n_initial + n_replication which could be null as well both fields
@@ -45,7 +44,7 @@ object Entities {
 
   case class IndexVariantTable(associations: Seq[IndexVariantAssociation])
 
-  case class IndexVariantAssociation(tagVariant: FRM.Variant,
+  case class IndexVariantAssociation(tagVariant: DNA.Variant,
                                      studyId: String,
                                      pval: Double,
                                      nTotal: Int, // n_initial + n_replication which could be null as well both fields
@@ -58,12 +57,12 @@ object Entities {
                                      sas1000GProp: Option[Double],
                                      log10Abf: Option[Double],
                                      posteriorProbability: Option[Double])
-//
-//  case class ManhattanTable(studyId: String, associations: Vector[ManhattanAssociation])
-//
-//  case class ManhattanAssociation(variantId: String, pval: Double,
-//                                  bestGenes: Seq[(String, Double)], crediblbeSetSize: Option[Long],
-//                                  ldSetSize: Option[Long], totalSetSize: Long)
+
+  case class ManhattanTable(studyId: String, associations: Vector[ManhattanAssociation])
+
+  case class ManhattanAssociation(variantId: String, pval: Double,
+                                  bestGenes: Seq[(String, Double)], crediblbeSetSize: Option[Long],
+                                  ldSetSize: Option[Long], totalSetSize: Long)
 //
 //  case class V2DByStudy(index_variant_id: String, pval: Double,
 //                        credibleSetSize: Option[Long], ldSetSize: Option[Long], totalSetSize: Long, topGenes: Seq[(String, Double)])
@@ -308,21 +307,21 @@ object Entities {
       //      GetResult(r => Study(r.<<, r.<<, r.<<, StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?, r.<<?,
       //        StrSeqRep(r.<<), StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?))
 
-      //    implicit val getIndexVariantAssoc: GetResult[IndexVariantAssociation] = GetResult(
-      //      r => {
-      //        val variant = Variant(r.<<, r.<<?)
-      //        IndexVariantAssociation(variant.right.get, r.<<,
-      //          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
-      //      }
-      //    )
+          implicit val getIndexVariantAssoc: GetResult[IndexVariantAssociation] = GetResult(
+            r => {
+              val variant = DNA.Variant(r.<<, r.<<?)
+              IndexVariantAssociation(variant.right.get, r.<<,
+                r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
+            }
+          )
 
-      //    implicit val getTagVariantAssoc: GetResult[TagVariantAssociation] = GetResult(
-      //      r => {
-      //        val variant = Variant(r.<<, r.<<?)
-      //        TagVariantAssociation(variant.right.get, r.<<,
-      //          r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
-      //      }
-      //    )
+          implicit val getTagVariantAssoc: GetResult[TagVariantAssociation] = GetResult(
+            r => {
+              val variant = DNA.Variant(r.<<, r.<<?)
+              TagVariantAssociation(variant.right.get, r.<<,
+                r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?)
+            }
+          )
 
       //    implicit val getGeckoLine: GetResult[GeckoLine] = GetResult(
       //      r => {
@@ -345,26 +344,15 @@ object Entities {
       //      }
       //    )
 
-//      implicit val getScoredG2VLine: GetResult[ScoredG2VLine] = GetResult(
-//        r => {
-//          ScoredG2VLine(r.<<, r.<<, r.<<,
-//            (StrSeqRep(r.nextString()).rep zip DSeqRep(r.nextString()).rep).toMap,
-//            r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<)
-//        }
-//      )
+      implicit val getScoredG2VLine: GetResult[ScoredG2VLine] = GetResult(
+        r => {
+          ScoredG2VLine(r.<<, r.<<, r.<<,
+            (StrSeqRep(r.nextString()).rep zip DSeqRep(r.nextString()).rep).toMap,
+            r.<<, r.<<, r.<<, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<)
+        }
+      )
 
-      //    implicit def frm2gqlVariant = (frm: FRM.Variant) => Variant(variantId=frm.id, rsId = frm.rsId)
-
-      //implicit def frm2gqlVariant(frm: FRM.Variant): DNA.Variant = DNA.Variant(
-      //  position=Position(frm.chromosome, frm.position),
-      //  refAllele=frm.refAllele,
-      //  altAllele=frm.altAllele,
-      //  rsId=frm.rsId,
-      //  nearestGeneId=frm.nearestGeneId,
-      //  nearestCodingGeneId=frm.nearestCodingGeneId
-      //)
-
-      //    implicit val frm2gqlVariant: DNA.Variant = DNA.Variant(variantId=frm.id, rsId = frm.rsId)
+      implicit def frm2dnaVariant(v: FRM.Variant): DNA.Variant = DNA.Variant(DNA.Position(v.chromosome, v.position), v.refAllele, v.altAllele, v.rsId, v.nearestGeneId, v.nearestCodingGeneId)
     }
 
   }

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -210,7 +210,7 @@ object Entities {
               case 1 => true
               case _ => false
             }),
-            None
+            Seq.empty
           )
           )
 

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -22,21 +22,21 @@ object Entities {
 //                               distinctA: Int, distinctB: Int)
 //
 //
-//  case class TagVariantTable(associations: Vector[TagVariantAssociation])
-//
-//  case class TagVariantAssociation(indexVariant: Variant,
-//                                   studyId: String,
-//                                   pval: Double,
-//                                   nTotal: Int, // n_initial + n_replication which could be null as well both fields
-//                                   nCases: Int,
-//                                   r2: Option[Double],
-//                                   afr1000GProp: Option[Double],
-//                                   amr1000GProp: Option[Double],
-//                                   eas1000GProp: Option[Double],
-//                                   eur1000GProp: Option[Double],
-//                                   sas1000GProp: Option[Double],
-//                                   log10Abf: Option[Double],
-//                                   posteriorProbability: Option[Double])
+  case class TagVariantTable(associations: Seq[TagVariantAssociation])
+
+  case class TagVariantAssociation(indexVariant: FRM.Variant,
+                                   studyId: String,
+                                   pval: Double,
+                                   nTotal: Int, // n_initial + n_replication which could be null as well both fields
+                                   nCases: Int,
+                                   r2: Option[Double],
+                                   afr1000GProp: Option[Double],
+                                   amr1000GProp: Option[Double],
+                                   eas1000GProp: Option[Double],
+                                   eur1000GProp: Option[Double],
+                                   sas1000GProp: Option[Double],
+                                   log10Abf: Option[Double],
+                                   posteriorProbability: Option[Double])
 //
 //
 //  case class IndexVariantTable(associations: Vector[IndexVariantAssociation])

--- a/app/models/Entities.scala
+++ b/app/models/Entities.scala
@@ -16,15 +16,15 @@ object Entities {
   implicit val variantHasId = HasId[FRM.Variant, String](_.id)
   implicit val studyHasId = HasId[FRM.Study, String](_.studyId)
 
-//  case class OverlapRow(stid: String, numOverlapLoci: Int)
-//
-//  case class OverlappedLociStudy(studyId: String, topOverlappedStudies: IndexedSeq[OverlapRow])
-//
-//  case class OverlappedVariantsStudy(studyId: String, overlaps: Seq[OverlappedVariant])
-//
-//  case class OverlappedVariant(variantIdA: String, variantIdB: String, overlapAB: Int,
-//                               distinctA: Int, distinctB: Int)
-//
+  case class OverlapRow(stid: String, numOverlapLoci: Int)
+
+  case class OverlappedLociStudy(studyId: String, topOverlappedStudies: IndexedSeq[OverlapRow])
+
+  case class OverlappedVariantsStudy(studyId: String, overlaps: Seq[OverlappedVariant])
+
+  case class OverlappedVariant(variantIdA: String, variantIdB: String, overlapAB: Int,
+                               distinctA: Int, distinctB: Int)
+
   case class TagVariantTable(associations: Seq[TagVariantAssociation])
 
   case class TagVariantAssociation(indexVariant: DNA.Variant,
@@ -63,71 +63,71 @@ object Entities {
   case class ManhattanAssociation(variantId: String, pval: Double,
                                   bestGenes: Seq[(String, Double)], crediblbeSetSize: Option[Long],
                                   ldSetSize: Option[Long], totalSetSize: Long)
-//
-//  case class V2DByStudy(index_variant_id: String, pval: Double,
-//                        credibleSetSize: Option[Long], ldSetSize: Option[Long], totalSetSize: Long, topGenes: Seq[(String, Double)])
 
-  //  case class StudyInfo(study: Option[Study])
-  //
-  //  object Study {
-  //    implicit val hasId = HasId[Study, String](_.studyId)
-  //  }
-  //
-  //  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
-  //                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
-  //                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
-  //                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
-  //                   traitCategory: Option[String])
+  case class V2DByStudy(index_variant_id: String, pval: Double,
+                        credibleSetSize: Option[Long], ldSetSize: Option[Long], totalSetSize: Long, topGenes: Seq[(String, Double)])
 
-  //  case class PheWASTable(associations: Vector[VariantPheWAS])
-  //  case class VariantPheWAS(stid: String, pval: Double, beta: Double, se: Double, eaf: Double, maf: Double,
-  //                           nSamplesVariant: Option[Long], nSamplesStudy: Option[Long], nCasesStudy: Option[Long],
-  //                           nCasesVariant: Option[Long], oddRatio: Option[Double], chip: String, info: Option[Double])
-  //
-  //  case class GeneTagVariant(geneId: String, tagVariantId: String, overallScore: Double)
-  //  case class TagVariantIndexVariantStudy(tagVariantId: String, indexVariantId: String, studyId: String,
-  //                                         r2: Option[Double], pval: Double, posteriorProb: Option[Double])
-  //  case class Gecko(geneIds: Seq[String], tagVariants: Seq[Variant], indexVariants: Seq[Variant],
-  //                   studies: Seq[String], geneTagVariants: Seq[GeneTagVariant],
-  //                   tagVariantIndexVariantStudies: Seq[TagVariantIndexVariantStudy])
-  //  case class GeckoLine(geneId: String, tagVariant: Variant, indexVariant: Variant, studyId: String,
-  //                       geneTagVariant: GeneTagVariant, tagVariantIndexVariantStudy: TagVariantIndexVariantStudy)
+    case class StudyInfo(study: Option[Study])
 
-  //  object Gecko {
-  //    def apply(geckoLines: Seq[GeckoLine], geneIdsInLoci: Set[String] = Set.empty): Option[Gecko] = {
-  //      if (geckoLines.isEmpty)
-  //        Some(Gecko(Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty))
-  //      else {
-  //        var geneIds: Set[String] = Set.empty
-  //        var tagVariants: Set[Variant] = Set.empty
-  //        var indexVariants: Set[Variant] = Set.empty
-  //        var studies: Set[String] = Set.empty
-  //        var tagVariantIndexVariantStudies: Set[TagVariantIndexVariantStudy] = Set.empty
-  //        var geneTagVariants: Set[GeneTagVariant] = Set.empty
-  //
-  //        geckoLines.foreach(line => {
-  //          geneIds += line.geneId
-  //          tagVariants += line.tagVariant
-  //          indexVariants += line.indexVariant
-  //          studies += line.studyId
-  //          geneTagVariants += line.geneTagVariant
-  //          tagVariantIndexVariantStudies += line.tagVariantIndexVariantStudy
-  //        })
-  //
-  //        // breakOut could be a good way to map virtually to a other collection of a different type
-  //        // https://stackoverflow.com/questions/46509951/how-do-i-efficiently-count-distinct-fields-in-a-collection
-  //        // val genes = geckoLines.map(_.gene)(breakOut).toSet.toSeq
-  //         Some(Gecko((geneIds union geneIdsInLoci).toSeq, tagVariants.toSeq, indexVariants.toSeq, studies.toSeq,
-  //                  geneTagVariants.toSeq, tagVariantIndexVariantStudies.toSeq))
-  //      }
-  //    }
-  //  }
+    object Study {
+      implicit val hasId = HasId[Study, String](_.studyId)
+    }
 
-  //  case class VariantSearchResult (variant: Variant)
+    case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
+                     pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
+                     pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
+                     nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
+                     traitCategory: Option[String])
 
-  //  case class SearchResultSet(totalGenes: Long, genes: Seq[FRM.Gene],
-  //                             totalVariants: Long, variants: Seq[VariantSearchResult],
-  //                             totalStudies: Long, studies: Seq[FRM.Study])
+    case class PheWASTable(associations: Vector[VariantPheWAS])
+    case class VariantPheWAS(stid: String, pval: Double, beta: Double, se: Double, eaf: Double, maf: Double,
+                             nSamplesVariant: Option[Long], nSamplesStudy: Option[Long], nCasesStudy: Option[Long],
+                             nCasesVariant: Option[Long], oddRatio: Option[Double], chip: String, info: Option[Double])
+
+    case class GeneTagVariant(geneId: String, tagVariantId: String, overallScore: Double)
+    case class TagVariantIndexVariantStudy(tagVariantId: String, indexVariantId: String, studyId: String,
+                                           r2: Option[Double], pval: Double, posteriorProb: Option[Double])
+    case class Gecko(geneIds: Seq[String], tagVariants: Seq[Variant], indexVariants: Seq[Variant],
+                     studies: Seq[String], geneTagVariants: Seq[GeneTagVariant],
+                     tagVariantIndexVariantStudies: Seq[TagVariantIndexVariantStudy])
+    case class GeckoLine(geneId: String, tagVariant: Variant, indexVariant: Variant, studyId: String,
+                         geneTagVariant: GeneTagVariant, tagVariantIndexVariantStudy: TagVariantIndexVariantStudy)
+
+    object Gecko {
+      def apply(geckoLines: Seq[GeckoLine], geneIdsInLoci: Set[String] = Set.empty): Option[Gecko] = {
+        if (geckoLines.isEmpty)
+          Some(Gecko(Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty))
+        else {
+          var geneIds: Set[String] = Set.empty
+          var tagVariants: Set[Variant] = Set.empty
+          var indexVariants: Set[Variant] = Set.empty
+          var studies: Set[String] = Set.empty
+          var tagVariantIndexVariantStudies: Set[TagVariantIndexVariantStudy] = Set.empty
+          var geneTagVariants: Set[GeneTagVariant] = Set.empty
+
+          geckoLines.foreach(line => {
+            geneIds += line.geneId
+            tagVariants += line.tagVariant
+            indexVariants += line.indexVariant
+            studies += line.studyId
+            geneTagVariants += line.geneTagVariant
+            tagVariantIndexVariantStudies += line.tagVariantIndexVariantStudy
+          })
+
+          // breakOut could be a good way to map virtually to a other collection of a different type
+          // https://stackoverflow.com/questions/46509951/how-do-i-efficiently-count-distinct-fields-in-a-collection
+          // val genes = geckoLines.map(_.gene)(breakOut).toSet.toSeq
+           Some(Gecko((geneIds union geneIdsInLoci).toSeq, tagVariants.toSeq, indexVariants.toSeq, studies.toSeq,
+                    geneTagVariants.toSeq, tagVariantIndexVariantStudies.toSeq))
+        }
+      }
+    }
+
+    case class VariantSearchResult (variant: Variant)
+
+    case class SearchResultSet(totalGenes: Long, genes: Seq[FRM.Gene],
+                               totalVariants: Long, variants: Seq[VariantSearchResult],
+                               totalStudies: Long, studies: Seq[FRM.Study])
 
   case class Tissue(id: String) {
     lazy val name: Option[String] = Option(id.replace("_", " ").toLowerCase.capitalize)
@@ -202,110 +202,110 @@ object Entities {
 
   object ESImplicits {
 
-//    implicit object GeneHitReader extends HitReader[FRM.Gene] {
-//      override def read(hit: Hit): Either[Throwable, FRM.Gene] = {
-//        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
-//        else {
-//          val mv = hit.sourceAsMap
-//
-//          Right(FRM.Gene(mv("gene_id").toString,
-//            Option(mv("gene_name").asInstanceOf[String]),
-//            Option(mv("biotype").asInstanceOf[String]),
-//            Option(mv("chr").toString),
-//            Option(mv("start").asInstanceOf[Int]),
-//            Option(mv("end").asInstanceOf[Int]),
-//            Option(mv("tss").asInstanceOf[Int]),
-//            Option(mv("fwdstrand").asInstanceOf[Int] match {
-//              case 0 => false
-//              case 1 => true
-//              case _ => false
-//            }),
-//            Seq.empty
-//          )
-//          )
-//
-//          //          Right(FRM.Gene(mv("gene_id").toString,
-//          //            Option(mv("gene_name").asInstanceOf[String]),
-//          //            Option(mv("start").asInstanceOf[Int]),
-//          //            Option(mv("end").asInstanceOf[Int]),
-//          //            Option(mv("chr").toString),
-//          //            Option(mv("tss").asInstanceOf[Int]),
-//          //            Option(mv("biotype").asInstanceOf[String]),
-//          //            Option(mv("fwdstrand").asInstanceOf[Int] match {
-//          //              case 0 => false
-//          //              case 1 => true
-//          //              case _ => false
-//          //            })
-//          //            )
-//          //          )
-//        }
-//      }
-//    }
+    implicit object GeneHitReader extends HitReader[FRM.Gene] {
+      override def read(hit: Hit): Either[Throwable, FRM.Gene] = {
+        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
+        else {
+          val mv = hit.sourceAsMap
 
-    //    implicit object VariantHitReader extends HitReader[VariantSearchResult] {
-    //      override def read(hit: Hit): Either[Throwable, VariantSearchResult] = {
-    //        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
-    //        else {
-    //          val mv = hit.sourceAsMap
-    //
-    //          val variant = Variant(Position(mv("chr_id").toString, mv("position").asInstanceOf[Int]),
-    //            mv("ref_allele").toString, mv("alt_allele").toString, Option(mv("rs_id").toString))
-    //
-    //          Right(VariantSearchResult(variant))
-    //        }
-    //      }
-    //    }
+          Right(FRM.Gene(mv("gene_id").toString,
+            Option(mv("gene_name").asInstanceOf[String]),
+            Option(mv("biotype").asInstanceOf[String]),
+            Option(mv("chr").toString),
+            Option(mv("start").asInstanceOf[Int]),
+            Option(mv("end").asInstanceOf[Int]),
+            Option(mv("tss").asInstanceOf[Int]),
+            Option(mv("fwdstrand").asInstanceOf[Int] match {
+              case 0 => false
+              case 1 => true
+              case _ => false
+            }),
+            Seq.empty
+          )
+          )
 
-    //    implicit object StudyHitReader extends HitReader[FRM.Study] {
-    //      override def read(hit: Hit): Either[Throwable, FRM.Study] = {
-    //        if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
-    //        else {
-    //          val mv = hit.sourceAsMap
-    //
-    //          Right(FRM.Study(mv("study_id").toString,
-    //            mv.get("trait_code").map(_.toString).get,
-    //            mv.get("trait_reported").map(_.toString).get,
-    //            mv.get("trait_efos").map(_.asInstanceOf[Seq[String]]).get,
-    //            mv.get("pmid").map(_.asInstanceOf[String]),
-    //            mv.get("pub_date").map(_.asInstanceOf[String]),
-    //            mv.get("pub_journal").map(_.asInstanceOf[String]),
-    //            mv.get("pub_title").map(_.asInstanceOf[String]),
-    //            mv.get("pub_author").map(_.asInstanceOf[String]),
-    //            mv.get("ancestry_initial").map(_.asInstanceOf[Seq[String]]).get,
-    //            mv.get("ancestry_replication").map(_.asInstanceOf[Seq[String]]).get,
-    //            mv.get("n_initial").map(_.asInstanceOf[Int].toLong),
-    //            mv.get("n_replication").map(_.asInstanceOf[Int].toLong),
-    //            mv.get("n_cases").map(_.asInstanceOf[Int].toLong),
-    //            mv.get("trait_category").map(_.asInstanceOf[String]))
-    //          )
-    //        }
-    //      }
-    //    }
+          //          Right(FRM.Gene(mv("gene_id").toString,
+          //            Option(mv("gene_name").asInstanceOf[String]),
+          //            Option(mv("start").asInstanceOf[Int]),
+          //            Option(mv("end").asInstanceOf[Int]),
+          //            Option(mv("chr").toString),
+          //            Option(mv("tss").asInstanceOf[Int]),
+          //            Option(mv("biotype").asInstanceOf[String]),
+          //            Option(mv("fwdstrand").asInstanceOf[Int] match {
+          //              case 0 => false
+          //              case 1 => true
+          //              case _ => false
+          //            })
+          //            )
+          //          )
+        }
+      }
+    }
+
+        implicit object VariantHitReader extends HitReader[VariantSearchResult] {
+          override def read(hit: Hit): Either[Throwable, VariantSearchResult] = {
+            if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
+            else {
+              val mv = hit.sourceAsMap
+
+              val variant = Variant(Position(mv("chr_id").toString, mv("position").asInstanceOf[Int]),
+                mv("ref_allele").toString, mv("alt_allele").toString, Option(mv("rs_id").toString))
+
+              Right(VariantSearchResult(variant))
+            }
+          }
+        }
+
+        implicit object StudyHitReader extends HitReader[FRM.Study] {
+          override def read(hit: Hit): Either[Throwable, FRM.Study] = {
+            if (hit.isSourceEmpty) Left(new NoSuchFieldError("source object is empty"))
+            else {
+              val mv = hit.sourceAsMap
+
+              Right(FRM.Study(mv("study_id").toString,
+                mv.get("trait_code").map(_.toString).get,
+                mv.get("trait_reported").map(_.toString).get,
+                mv.get("trait_efos").map(_.asInstanceOf[Seq[String]]).get,
+                mv.get("pmid").map(_.asInstanceOf[String]),
+                mv.get("pub_date").map(_.asInstanceOf[String]),
+                mv.get("pub_journal").map(_.asInstanceOf[String]),
+                mv.get("pub_title").map(_.asInstanceOf[String]),
+                mv.get("pub_author").map(_.asInstanceOf[String]),
+                mv.get("ancestry_initial").map(_.asInstanceOf[Seq[String]]).get,
+                mv.get("ancestry_replication").map(_.asInstanceOf[Seq[String]]).get,
+                mv.get("n_initial").map(_.asInstanceOf[Int].toLong),
+                mv.get("n_replication").map(_.asInstanceOf[Int].toLong),
+                mv.get("n_cases").map(_.asInstanceOf[Int].toLong),
+                mv.get("trait_category").map(_.asInstanceOf[String]))
+              )
+            }
+          }
+        }
       }
 
     object DBImplicits {
-//      implicit val getV2DByStudy: GetResult[V2DByStudy] = {
-//        def toGeneScoreTuple(geneIds: Seq[String], geneScores: Seq[Double]): Seq[(String, Double)] = {
-//          val ordScored = (geneIds zip geneScores)
-//            .sortBy(_._2)(Ordering[Double].reverse)
-//
-//          if (ordScored.isEmpty) ordScored
-//          else {
-//            ordScored.takeWhile(_._2 == ordScored.head._2)
-//          }
-//        }
-//
-//        GetResult(r => V2DByStudy(r.<<, r.<<, r.<<?, r.<<?, r.<<,
-//          toGeneScoreTuple(StrSeqRep(r.<<), DSeqRep(r.<<))))
-//      }
+      implicit val getV2DByStudy: GetResult[V2DByStudy] = {
+        def toGeneScoreTuple(geneIds: Seq[String], geneScores: Seq[Double]): Seq[(String, Double)] = {
+          val ordScored = (geneIds zip geneScores)
+            .sortBy(_._2)(Ordering[Double].reverse)
 
-      //    implicit val getSumStatsByVariantPheWAS: GetResult[VariantPheWAS] =
-      //      GetResult(r => VariantPheWAS(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<,
-      //        r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<?))
+          if (ordScored.isEmpty) ordScored
+          else {
+            ordScored.takeWhile(_._2 == ordScored.head._2)
+          }
+        }
 
-      //    implicit val getStudy: GetResult[Study] =
-      //      GetResult(r => Study(r.<<, r.<<, r.<<, StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?, r.<<?,
-      //        StrSeqRep(r.<<), StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?))
+        GetResult(r => V2DByStudy(r.<<, r.<<, r.<<?, r.<<?, r.<<,
+          toGeneScoreTuple(StrSeqRep(r.<<), DSeqRep(r.<<))))
+      }
+
+          implicit val getSumStatsByVariantPheWAS: GetResult[VariantPheWAS] =
+            GetResult(r => VariantPheWAS(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<,
+              r.<<?, r.<<?, r.<<?, r.<<?, r.<<?, r.<<, r.<<?))
+
+          implicit val getStudy: GetResult[Study] =
+            GetResult(r => Study(r.<<, r.<<, r.<<, StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?, r.<<?,
+              StrSeqRep(r.<<), StrSeqRep(r.<<), r.<<?, r.<<?, r.<<?, r.<<?))
 
           implicit val getIndexVariantAssoc: GetResult[IndexVariantAssociation] = GetResult(
             r => {
@@ -323,26 +323,26 @@ object Entities {
             }
           )
 
-      //    implicit val getGeckoLine: GetResult[GeckoLine] = GetResult(
-      //      r => {
-      //        val tagVariant = Variant(r.<<, r.<<?).right.get
-      //        val indexVariant = Variant(r.<<, r.<<?).right.get
-      //
-      //        val geneId = r.nextString()
-      //        val studyId: String = r.<<
-      //
-      //        val r2 = r.nextDoubleOption()
-      //        val posteriorProb = r.nextDoubleOption()
-      //        val pval = r.nextDouble()
-      //        val overallScore = r.nextDouble()
-      //
-      //        val geneTagVariant = GeneTagVariant(geneId, tagVariant.id, overallScore)
-      //        val tagVariantIndexVariantStudy = TagVariantIndexVariantStudy(tagVariant.id, indexVariant.id,
-      //          studyId, r2, pval, posteriorProb)
-      //
-      //        GeckoLine(geneId, tagVariant, indexVariant, studyId, geneTagVariant, tagVariantIndexVariantStudy)
-      //      }
-      //    )
+          implicit val getGeckoLine: GetResult[GeckoLine] = GetResult(
+            r => {
+              val tagVariant = Variant(r.<<, r.<<?).right.get
+              val indexVariant = Variant(r.<<, r.<<?).right.get
+
+              val geneId = r.nextString()
+              val studyId: String = r.<<
+
+              val r2 = r.nextDoubleOption()
+              val posteriorProb = r.nextDoubleOption()
+              val pval = r.nextDouble()
+              val overallScore = r.nextDouble()
+
+              val geneTagVariant = GeneTagVariant(geneId, tagVariant.id, overallScore)
+              val tagVariantIndexVariantStudy = TagVariantIndexVariantStudy(tagVariant.id, indexVariant.id,
+                studyId, r2, pval, posteriorProb)
+
+              GeckoLine(geneId, tagVariant, indexVariant, studyId, geneTagVariant, tagVariantIndexVariantStudy)
+            }
+          )
 
       implicit val getScoredG2VLine: GetResult[ScoredG2VLine] = GetResult(
         r => {

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -9,13 +9,6 @@ object FRM {
     *  a MappedColumnType, which likely does the conversion in scala.
     */
 
-//  def asIntArray = SimpleExpression.unary[String, String] { (str, qb) =>
-//    qb.sqlBuilder += "CAST("
-//    qb.expr(str)
-//    qb.sqlBuilder += ", 'Array(UInt32)') AS "
-//    qb.expr(str)
-//  }
-
   implicit val seqLongType = MappedColumnType.base[Seq[Long], String](
     { ls => ls.mkString("[", ",", "]") },
     { s => s.filterNot("[]".toSet).split(",").map(_.toLong).toSeq }
@@ -181,70 +174,4 @@ object FRM {
 
   lazy val v2DsByStudy = TableQuery[V2DsByChrPos]
 
-  // --------------------------------------------------------
-  // V2G
-
-  case class V2GAssociation(typeId: String, sourceId: String, feature: String, qtlBeta: Option[Double],
-                            qtlSE: Option[Double], qtlPval: Option[Double], qtlScoreQ: Double,
-                            intervalScore: Option[Double], intervalScoreQ: Double,
-                            fpredMaxLabel: Option[String], fpredMaxScore: Option[Double])
-  case class V2G(geneId: String, tagId: String, tagChromosome: String, tagPosition: Long, association: V2GAssociation)
-
-  trait V2GAssociationFields extends Table[V2G] {
-    def typeId = column[String]("type_id")
-    def sourceId = column[String]("source_id")
-    def feature = column[String]("feature")
-    def qtlBeta = column[Option[Double]]("qtl_beta")
-    def qtlSE = column[Option[Double]]("qtl_se")
-    def qtlPval = column[Option[Double]]("qtl_pval")
-    def qtlScoreQ = column[Double]("qtl_score_q")
-    def intervalScore = column[Option[Double]]("interval_score")
-    def intervalScoreQ = column[Double]("interval_score_q")
-    def fpredMaxLabel = column[Option[String]]("fpred_max_label")
-    def fpredMaxScore = column[Option[Double]]("fpred_max_score")
-
-    def associationProjection = (typeId, sourceId, feature, qtlBeta, qtlSE, qtlPval, qtlScoreQ, intervalScore, intervalScoreQ, fpredMaxLabel, fpredMaxScore) <> (V2GAssociation.tupled, V2GAssociation.unapply)
-  }
-
-  class V2Gs(tag: Tag) extends Table[V2G](tag, "v2g") with V2GAssociationFields {
-    def geneId = column[String]("gene_id")
-    def tagId = column[String]("variant_id")
-    def tagChromosome = column[String]("chr_id")
-    def tagPosition = column[Long]("position")
-    def * = (geneId, tagId, tagChromosome, tagPosition, associationProjection) <> (V2G.tupled, V2G.unapply)
-  }
-
-  lazy val v2Gs = TableQuery[V2Gs]
-
-  // --------------------------------------------------------
-  // V2G Overall
-
-  case class V2GOverall(chromosome: String, variantId: String, geneId: String, sourceList: Seq[String], sourceScoreList: Seq[Double], overallScore: Double)
-
-  class V2GsOverall(tag: Tag) extends Table[V2GOverall](tag, "v2g_score_by_overall") {
-    def chromosome = column[String]("chr_id")
-    def variantId = column[String]("variant_id")
-    def geneId = column[String]("gene_id")
-    def sourceList = column[Seq[String]]("source_list")
-    def sourceScoreList = column[Seq[Double]]("source_score_list")
-    def overallScore = column[Double]("overall_score")
-    def * = (chromosome, variantId, geneId, sourceList, sourceScoreList, overallScore) <> (V2GOverall.tupled, V2GOverall.unapply)
-  }
-
-  lazy val v2GsOverall = TableQuery[V2GsOverall]
-
-  // --------------------------------------------------------
-  // V2G Structure
-
-  case class V2GStructure(typeId: String, sourceId: String, featureSet: Seq[String], featureSetSize: Long)
-
-  class V2GsStructure(tag: Tag) extends Table[V2GStructure](tag, "v2g_structure") {
-    def typeId = column[String]("type_id")
-    def sourceId = column[String]("source_id")
-    def featureSet = column[Seq[String]]("feature_set")
-    def featureSetSize = column[Long]("feature_set_size")
-    def * = (typeId, sourceId, featureSet, featureSetSize) <> (V2GStructure.tupled, V2GStructure.unapply)
-  }
-
-  lazy val v2GsStructure = TableQuery[V2GsStructure]
 }

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -3,8 +3,29 @@ package models
 import slick.jdbc.H2Profile.api._
 
 object FRM {
+  /**  In order to convert the db's string representation to Seq[Long] for the exons
+    *  the sql approach can use `cast(exons, 'Array(UInt32)') AS exons`, which might
+    *  be achievable with a SimpleExpression. Alternatively (and working), there is
+    *  a MappedColumnType, which likely does the conversion in scala.
+    */
+
+//  def asIntArray = SimpleExpression.unary[String, String] { (str, qb) =>
+//    qb.sqlBuilder += "CAST("
+//    qb.expr(str)
+//    qb.sqlBuilder += ", 'Array(UInt32)') AS "
+//    qb.expr(str)
+//  }
+
+  implicit val seqLongType = MappedColumnType.base[Seq[Long], String](
+    { ls => ls.mkString("[", ",", "]") },
+    { s => s.filterNot("[]".toSet).split(",").map(_.toLong).toSeq }
+  )
+  // --------------------------------------------------------
+  // GENE
+
   case class Gene(id: String, symbol: Option[String], bioType: Option[String] = None, chromosome: Option[String] = None,
-                  tss: Option[Long] = None, start: Option[Long] = None, end: Option[Long] = None, fwd: Option[Boolean] = None, exons: Option[String] = None)
+                  tss: Option[Long] = None, start: Option[Long] = None, end: Option[Long] = None,
+                  fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
 
   class Genes(tag: Tag) extends Table[Gene](tag, "gene") {
     def id = column[String]("gene_id")
@@ -15,9 +36,39 @@ object FRM {
     def start = column[Option[Long]]("start")
     def end = column[Option[Long]]("end")
     def fwd = column[Option[Boolean]]("fwdstrand")
-    def exons = column[Option[String]]("exons")
+    def exons = column[Seq[Long]]("exons")
     def * = (id, symbol, bioType, chromosome, tss, start, end, fwd, exons) <> (Gene.tupled, Gene.unapply)
   }
 
   lazy val genes = TableQuery[Genes]
+
+//  // --------------------------------------------------------
+//  // STUDY
+//
+//  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
+//                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
+//                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
+//                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
+//                   traitCategory: Option[String])
+//
+//  class Studies(tag: Tag) extends Table[Study](tag, "studies") {
+//    def studyId = column[String]("study_id")
+//    def traitCode = column[String]("trait_code")
+//    def traitReported = column[String]("trait_reported")
+//    def traitEfos = column[Seq[String]]("trait_efos")
+//    def pubId = column[Option[String]]("pmid")
+//    def pubDate = column[Option[String]]("pub_data")
+//    def pubJournal = column[Option[String]]("pub_journal")
+//    def pubTitle = column[Option[String]]("pub_title")
+//    def pubAuthor = column[Option[String]]("pub_author")
+//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
+//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
+//    def nInitial = column[Option[Long]]("n_initial")
+//    def nCases = column[Option[Long]]("n_cases")
+//    def traitCategory = column[Option[String]]("trait_category")
+//  }
+//
+//  lazy val studies = TableQuery[Studies]
+//
+//  // --------------------------------------------------------
 }

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -1,6 +1,8 @@
 package models
 
+import models.Entities.TagVariantAssociation
 import slick.jdbc.H2Profile.api._
+import slick.lifted.MappedProjection
 
 object FRM {
   /**  In order to convert the db's string representation to Seq[Long] for the exons
@@ -50,11 +52,20 @@ object FRM {
   // --------------------------------------------------------
   // VARIANT
 
-  case class SimpleVariant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String])
+//  case class SimpleVariant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String])
   case class Variant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
                      nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None)
-//  case class LiftedVariant(id: Rep[String], chromosome: Rep[String], position: Rep[Long], refAllele: Rep[String], altAllele: Rep[String], rsId: Rep[Option[String]],
-//                     nearestGeneId: Rep[Option[String]] = None, nearestCodingGeneId: Rep[Option[String]] = None)
+//  object Variant {
+////    def apply(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
+////      nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None): Variant = new Variant(id, chromosome, position, refAllele, altAllele, rsId,
+////      nearestGeneId, nearestCodingGeneId)
+////    def apply(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String]): Variant = new Variant(id, chromosome, position, refAllele, altAllele, rsId,)
+////    def unapply(v: Variant) = (v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId, v.nearestGeneId, v.nearestCodingGeneId)
+////    def unapply(v: Variant) = (v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
+//  }
+//  def simpleToFullVariant(v: SimpleVariant): Variant = {
+//    Variant(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId, None, None)
+//  }
 
   class Variants(tag: Tag) extends Table[Variant](tag, "variants") {
     def id = column[String]("variant_id")
@@ -78,11 +89,6 @@ object FRM {
                    pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
                    nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
                    traitCategory: Option[String])
-//  case class LiftedStudy(studyId: Rep[String], traitCode: Rep[String], traitReported: Rep[String], traitEfos: Rep[Seq[String]],
-//                   pubId: Rep[Option[String]], pubDate: Rep[Option[String]], pubJournal: Rep[Option[String]], pubTitle: Rep[Option[String]],
-//                   pubAuthor: Rep[Option[String]], ancestryInitial: Rep[Seq[String]], ancestryReplication: Rep[Seq[String]],
-//                   nInitial: Rep[Option[Long]], nReplication: Rep[Option[Long]], nCases: Rep[Option[Long]],
-//                   traitCategory: Rep[Option[String]])
 
   class Studies(tag: Tag) extends Table[Study](tag, "studies") {
     def studyId = column[String]("study_id")
@@ -125,18 +131,125 @@ object FRM {
 //                  afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
 //                )
   case class V2DAssociation(
-                      pval: Option[Double], r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
+                      pval: Double, r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
                       afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
                     )
 //  case class LiftedV2DAssociation(
 //                             pval: Rep[Option[Double]], r2: Rep[Option[Double]], log10Abf: Rep[Option[Double]], posteriorProbability: Rep[Option[Double]],
 //                             afr1000GProp: Rep[Option[Double]], amr1000GProp: Rep[Option[Double]], eas1000GProp: Rep[Option[Double]], eur1000GProp: Rep[Option[Double]], sas1000GProp: Rep[Option[Double]]
 //                           )
-  case class V2D(tag: SimpleVariant, lead: SimpleVariant, study: Study, association: V2DAssociation)
+  case class V2D(tag: Variant, lead: Variant, study: Study, association: V2DAssociation)
 //  case class LiftedV2D(tag: LiftedVariant, lead: LiftedVariant, study: LiftedStudy, association: LiftedV2DAssociation)
 //  implicit object V2DShape extends CaseClassShape(LiftedV2D.tupled, V2D.tupled)
 
-  class V2Ds(tag: Tag) extends Table[V2D](tag, "d2v2g") {
+//  trait V2DFields {
+//    def tagId = column[String]("variant_id")
+//    def tagChromosome = column[String]("chr_id")
+//    def tagPosition = column[Long]("position")
+//    def tagRefAllele = column[String]("ref_allele")
+//    def tagAltAllele = column[String]("alt_allele")
+//    def tagRsId = column[Option[String]]("rs_id")
+//
+//    def leadId = column[String]("index_variant_id")
+//    def leadChromosome = column[String]("index_chr_id")
+//    def leadPosition = column[Long]("index_position")
+//    def leadRefAllele = column[String]("index_ref_allele")
+//    def leadAltAllele = column[String]("index_alt_allele")
+//    def leadRsId = column[Option[String]]("index_rs_id")
+//
+//    def studyId = column[String]("stid")
+//    def traitCode = column[String]("trait_code")
+//    def traitReported = column[String]("trait_reported")
+//    def traitEfos = column[Seq[String]]("trait_efos")
+//    def pubId = column[Option[String]]("pmid")
+//    def pubDate = column[Option[String]]("pub_data")
+//    def pubJournal = column[Option[String]]("pub_journal")
+//    def pubTitle = column[Option[String]]("pub_title")
+//    def pubAuthor = column[Option[String]]("pub_author")
+//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
+//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
+//    def nInitial = column[Option[Long]]("n_initial")
+//    def nReplication = column[Option[Long]]("n_replication")
+//    def nCases = column[Option[Long]]("n_cases")
+//    def traitCategory = column[Option[String]]("trait_category")
+//
+//    def pval = column[Option[Double]]("pval")
+//    def r2 = column[Option[Double]]("r2")
+//    def log10Abf = column[Option[Double]]("log10_abf")
+//    def posteriorProbability = column[Option[Double]]("posterior_prob")
+//
+//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
+//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
+//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
+//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
+//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
+//
+//    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+//    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
+//    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
+//
+//    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
+//  }
+
+//  class V2DsByStudy(tag: Tag) extends Table[V2D](tag, "v2d_by_stchr") {
+//    def tagId = column[String]("variant_id")
+//    def tagChromosome = column[String]("chr_id")
+//    def tagPosition = column[Long]("position")
+//    def tagRefAllele = column[String]("ref_allele")
+//    def tagAltAllele = column[String]("alt_allele")
+//    def tagRsId = column[Option[String]]("rs_id")
+//
+//    def leadId = column[String]("index_variant_id")
+//    def leadChromosome = column[String]("index_chr_id")
+//    def leadPosition = column[Long]("index_position")
+//    def leadRefAllele = column[String]("index_ref_allele")
+//    def leadAltAllele = column[String]("index_alt_allele")
+//    def leadRsId = column[Option[String]]("index_rs_id")
+//
+//    def studyId = column[String]("stid")
+//    def traitCode = column[String]("trait_code")
+//    def traitReported = column[String]("trait_reported")
+//    def traitEfos = column[Seq[String]]("trait_efos")
+//    def pubId = column[Option[String]]("pmid")
+//    def pubDate = column[Option[String]]("pub_data")
+//    def pubJournal = column[Option[String]]("pub_journal")
+//    def pubTitle = column[Option[String]]("pub_title")
+//    def pubAuthor = column[Option[String]]("pub_author")
+//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
+//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
+//    def nInitial = column[Option[Long]]("n_initial")
+//    def nReplication = column[Option[Long]]("n_replication")
+//    def nCases = column[Option[Long]]("n_cases")
+//    def traitCategory = column[Option[String]]("trait_category")
+//
+//    def pval = column[Double]("pval")
+//    def r2 = column[Option[Double]]("r2")
+//    def log10Abf = column[Option[Double]]("log10_abf")
+//    def posteriorProbability = column[Option[Double]]("posterior_prob")
+//
+//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
+//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
+//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
+//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
+//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
+//
+//    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+//    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
+//    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
+//    def nTotal = nInitial.getOrElse(0) + nReplication.getOrElse(0)
+//
+//    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
+//  }
+//  lazy val v2DsByStudy = TableQuery[V2DsByStudy]
+
+  def tupleToVariant (t: Tuple6[String, String, Long, String, String, Option[String]]) = Variant(t._1, t._2, t._3, t._4, t._5, t._6)
+  def variantToTuple (v: Variant) = Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
+
+  class V2DsByChrPos(tag: Tag) extends Table[V2D](tag, "v2d_by_chrpos") {
     def tagId = column[String]("variant_id")
     def tagChromosome = column[String]("chr_id")
     def tagPosition = column[Long]("position")
@@ -167,7 +280,7 @@ object FRM {
     def nCases = column[Option[Long]]("n_cases")
     def traitCategory = column[Option[String]]("trait_category")
 
-    def pval = column[Option[Double]]("pval")
+    def pval = column[Double]("pval")
     def r2 = column[Option[Double]]("r2")
     def log10Abf = column[Option[Double]]("log10_abf")
     def posteriorProbability = column[Option[Double]]("posterior_prob")
@@ -178,32 +291,29 @@ object FRM {
     def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
     def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
 
-    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
-    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+//    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (t => Variant(t._1, t._2, t._3, t._4, t._5, t._6), (v: Variant) => Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId))
+    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (tupleToVariant, variantToTuple)
+//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (tupleToVariant, variantToTuple)
     def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
       pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
     def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
 
-    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
-//    def * = LiftedV2D(
-//      LiftedVariant(tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId),
-//      LiftedVariant(leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId),
-//      LiftedStudy(studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
-//              pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory),
-//      LiftedV2DAssociation(pval, r2, log10Abf, posteriorProbability,
-//              afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp)
+//    def nTotal = nInitial.getOrElse(0) + nReplication.getOrElse(0)
+//    def asTagVariantAssociation = TagVariantAssociation(
+//      leadProjection, studyId, pval, nTotal, nCases.getOrElse(0),
+//      r2, afr1000GProp, amr1000GProp, eas1000GProp,
+//      eur1000GProp, sas1000GProp, log10Abf, posteriorProbability
 //    )
-//    def * = (
-//      tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId,
-//      leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId,
-//      studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
-//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory,
-//      pval, r2, log10Abf, posteriorProbability,
-//      afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp
-//    ) <> (V2D.tupled, V2D.unapply)
-  }
+//    def tagVariantAssociationProjection = (
+//      leadProjection, studyId, pval, nInitial.getOrElse(0) + nReplication.getOrElse(0), nCases.getOrElse(0),
+//      r2, afr1000GProp, amr1000GProp, eas1000GProp,
+//      eur1000GProp, sas1000GProp, log10Abf, posteriorProbability
+//    ) <> (TagVariantAssociation.tupled, TagVariantAssociation.unapply)
 
-  lazy val v2Ds = TableQuery[V2Ds]
+    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
+  }
+  lazy val v2DsByChrPos = TableQuery[V2DsByChrPos]
 
   // --------------------------------------------------------
 

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -20,6 +20,11 @@ object FRM {
     { ls => ls.mkString("[", ",", "]") },
     { s => s.filterNot("[]".toSet).split(",").map(_.toLong).toSeq }
   )
+  implicit val seqStringType = MappedColumnType.base[Seq[String], String](
+    { ss => ss.map("'" + _ + "'").mkString("[", ",", "]") },
+    { s => s.filterNot("[]".toSet).split(",").toSeq }
+  )
+
   // --------------------------------------------------------
   // GENE
 
@@ -42,17 +47,94 @@ object FRM {
 
   lazy val genes = TableQuery[Genes]
 
+  // --------------------------------------------------------
+  // VARIANT
+
+  case class Variant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
+                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None)
+
+  class Variants(tag: Tag) extends Table[Variant](tag, "variants") {
+    def id = column[String]("variant_id")
+    def chromosome = column[String]("chr_id")
+    def position = column[Long]("position")
+    def refAllele = column[String]("ref_allele")
+    def altAllele = column[String]("alt_allele")
+    def rsId = column[Option[String]]("rs_id")
+    def nearestGeneId = column[Option[String]]("gene_id")
+    def nearestCodingGeneId = column[Option[String]]("gene_id_prot_coding")
+    def * = (id, chromosome, position, refAllele, altAllele, rsId, nearestGeneId, nearestCodingGeneId) <> (Variant.tupled, Variant.unapply)
+  }
+
+  lazy val variants = TableQuery[Variants]
+
+  // --------------------------------------------------------
+  // STUDY
+
+  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
+                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
+                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
+                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
+                   traitCategory: Option[String])
+
+  class Studies(tag: Tag) extends Table[Study](tag, "studies") {
+    def studyId = column[String]("study_id")
+    def traitCode = column[String]("trait_code")
+    def traitReported = column[String]("trait_reported")
+    def traitEfos = column[Seq[String]]("trait_efos")
+    def pubId = column[Option[String]]("pmid")
+    def pubDate = column[Option[String]]("pub_date")
+    def pubJournal = column[Option[String]]("pub_journal")
+    def pubTitle = column[Option[String]]("pub_title")
+    def pubAuthor = column[Option[String]]("pub_author")
+    def ancestryInitial = column[Seq[String]]("ancestry_initial")
+    def ancestryReplication = column[Seq[String]]("ancestry_replication")
+    def nInitial = column[Option[Long]]("n_initial")
+    def nReplication = column[Option[Long]]("n_replication")
+    def nCases = column[Option[Long]]("n_cases")
+    def traitCategory = column[Option[String]]("trait_category")
+    def * = (
+      studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory
+    ) <> (Study.tupled, Study.unapply)
+  }
+
+  lazy val studies = TableQuery[Studies]
+
 //  // --------------------------------------------------------
-//  // STUDY
+//  // V2D_BY_CHRPOS
 //
-//  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
+//  case class V2D(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
 //                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
 //                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
 //                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
 //                   traitCategory: Option[String])
 //
-//  class Studies(tag: Tag) extends Table[Study](tag, "studies") {
-//    def studyId = column[String]("study_id")
+//  class V2DsByChrPos(tag: Tag) extends Table[V2D](tag, "v2d_by_chrpos") {
+//    def tagId = column[String]("variant_id")
+//    def tagChromosome = column[String]("chr_id")
+//    def tagPosition = column[Long]("position")
+//    def tagRefAllele = column[String]("ref_allele")
+//    def tagAltAllele = column[String]("alt_allele")
+//    def tagRsId = column[Option[String]]("rs_id")
+//    def leadId = column[String]("index_variant_id")
+//    def leadChromosome = column[String]("index_chr_id")
+//    def leadPosition = column[Long]("index_position")
+//    def leadRefAllele = column[String]("index_ref_allele")
+//    def leadAltAllele = column[String]("index_alt_allele")
+//    def leadRsId = column[Option[String]]("index_rs_id")
+//
+//    def studyId = column[String]("stid")
+//    def pval = column[Option[Double]]("pval")
+//    def r2 = column[Option[Double]]("r2")
+//    def log10Abf = column[Option[Double]]("log10_abf")
+//    def posteriorProbability = column[Option[Double]]("posterior_prob")
+//
+//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
+//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
+//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
+//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
+//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
+//
 //    def traitCode = column[String]("trait_code")
 //    def traitReported = column[String]("trait_reported")
 //    def traitEfos = column[Seq[String]]("trait_efos")
@@ -64,11 +146,16 @@ object FRM {
 //    def ancestryInitial = column[Seq[String]]("ancestry_initial")
 //    def ancestryReplication = column[Seq[String]]("ancestry_replication")
 //    def nInitial = column[Option[Long]]("n_initial")
+//    def nReplication = column[Option[Long]]("n_replication")
 //    def nCases = column[Option[Long]]("n_cases")
 //    def traitCategory = column[Option[String]]("trait_category")
+//    def * = (
+//      studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory
+//    ) <> (Study.tupled, Study.unapply)
 //  }
 //
-//  lazy val studies = TableQuery[Studies]
+//  lazy val v2DsByChrPos = TableQuery[V2DsByChrPos]
 //
 //  // --------------------------------------------------------
 }

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -1,0 +1,23 @@
+package models
+
+import slick.jdbc.H2Profile.api._
+
+object FRM {
+  case class Gene(id: String, symbol: Option[String], bioType: Option[String] = None, chromosome: Option[String] = None,
+                  tss: Option[Long] = None, start: Option[Long] = None, end: Option[Long] = None, fwd: Option[Boolean] = None, exons: Option[String] = None)
+
+  class Genes(tag: Tag) extends Table[Gene](tag, "gene") {
+    def id = column[String]("gene_id")
+    def symbol = column[Option[String]]("gene_name")
+    def bioType = column[Option[String]]("biotype")
+    def chromosome = column[Option[String]]("chr")
+    def tss = column[Option[Long]]("tss")
+    def start = column[Option[Long]]("start")
+    def end = column[Option[Long]]("end")
+    def fwd = column[Option[Boolean]]("fwdstrand")
+    def exons = column[Option[String]]("exons")
+    def * = (id, symbol, bioType, chromosome, tss, start, end, fwd, exons) <> (Gene.tupled, Gene.unapply)
+  }
+
+  lazy val genes = TableQuery[Genes]
+}

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -185,36 +185,10 @@ object FRM {
   // V2G
 
   case class V2GAssociation(typeId: String, sourceId: String, feature: String, qtlBeta: Option[Double],
-                            qtlSE: Option[Double], qtlPval: Option[Double], qtlScoreQ: Option[Double],
-                            intervalScore: Option[Double], intervalScoreQ: Option[Double],
-                            fpredMaxLabel: Option[Double], fpredMaxScore: Option[Double])
-  case class V2G(geneId: String, association: V2GAssociation)
-//  case class V2G(geneId: String, tag: Variant, association: V2GAssociation)
-
-//  def tupleToGene (t: Tuple9[String, Option[String], Option[String], Option[String], Option[Long], Option[Long], Option[Long], Option[Boolean], Seq[Long]]) = Gene(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
-//  def geneToTuple (g: Gene) = Some(g.id, g.symbol, g.bioType, g.chromosome, g.tss, g.start, g.end, g.fwd, g.exons)
-//
-//  trait GeneFields extends Table[V2G] {
-//    def id = column[String]("gene_id")
-////    def symbol = column[Option[String]]("gene_name")
-////    def chromosome = column[Option[String]]("gene_chr")
-////    def start = column[Option[Long]]("gene_start")
-////    def end = column[Option[Long]]("end")
-////    def fwd = column[Option[Boolean]]("fwdstrand")
-////    def exons = column[Seq[Long]]("exons")
-//
-////    def pval = column[Double]("pval")
-////    def r2 = column[Option[Double]]("r2")
-////    def log10Abf = column[Option[Double]]("log10_abf")
-////    def posteriorProbability = column[Option[Double]]("posterior_prob")
-////
-////    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
-////    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
-////    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
-////    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
-////    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
-//    def geneProjection = (id) <> (tupleToGene, geneToTuple)
-//  }
+                            qtlSE: Option[Double], qtlPval: Option[Double], qtlScoreQ: Double,
+                            intervalScore: Option[Double], intervalScoreQ: Double,
+                            fpredMaxLabel: Option[String], fpredMaxScore: Option[Double])
+  case class V2G(geneId: String, tagId: String, tagChromosome: String, tagPosition: Long, association: V2GAssociation)
 
   trait V2GAssociationFields extends Table[V2G] {
     def typeId = column[String]("type_id")
@@ -223,20 +197,21 @@ object FRM {
     def qtlBeta = column[Option[Double]]("qtl_beta")
     def qtlSE = column[Option[Double]]("qtl_se")
     def qtlPval = column[Option[Double]]("qtl_pval")
-    def qtlScoreQ = column[Option[Double]]("qtl_score_q")
+    def qtlScoreQ = column[Double]("qtl_score_q")
     def intervalScore = column[Option[Double]]("interval_score")
-    def intervalScoreQ = column[Option[Double]]("interval_score_q")
-    def fpredMaxLabel = column[Option[Double]]("fpred_max_label")
+    def intervalScoreQ = column[Double]("interval_score_q")
+    def fpredMaxLabel = column[Option[String]]("fpred_max_label")
     def fpredMaxScore = column[Option[Double]]("fpred_max_score")
 
     def associationProjection = (typeId, sourceId, feature, qtlBeta, qtlSE, qtlPval, qtlScoreQ, intervalScore, intervalScoreQ, fpredMaxLabel, fpredMaxScore) <> (V2GAssociation.tupled, V2GAssociation.unapply)
   }
 
   class V2Gs(tag: Tag) extends Table[V2G](tag, "v2g") with V2GAssociationFields {
-//  class V2Gs(tag: Tag) extends Table[V2G](tag, "v2g") with TagVariantFields with V2GAssociationFields {
     def geneId = column[String]("gene_id")
-    def * = (geneId, associationProjection) <> (V2G.tupled, V2G.unapply)
-//    def * = (geneId, tagProjection, associationProjection) <> (V2G.tupled, V2G.unapply)
+    def tagId = column[String]("variant_id")
+    def tagChromosome = column[String]("chr_id")
+    def tagPosition = column[Long]("position")
+    def * = (geneId, tagId, tagChromosome, tagPosition, associationProjection) <> (V2G.tupled, V2G.unapply)
   }
 
   lazy val v2Gs = TableQuery[V2Gs]

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -50,8 +50,11 @@ object FRM {
   // --------------------------------------------------------
   // VARIANT
 
+  case class SimpleVariant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String])
   case class Variant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
                      nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None)
+//  case class LiftedVariant(id: Rep[String], chromosome: Rep[String], position: Rep[Long], refAllele: Rep[String], altAllele: Rep[String], rsId: Rep[Option[String]],
+//                     nearestGeneId: Rep[Option[String]] = None, nearestCodingGeneId: Rep[Option[String]] = None)
 
   class Variants(tag: Tag) extends Table[Variant](tag, "variants") {
     def id = column[String]("variant_id")
@@ -75,6 +78,11 @@ object FRM {
                    pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
                    nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
                    traitCategory: Option[String])
+//  case class LiftedStudy(studyId: Rep[String], traitCode: Rep[String], traitReported: Rep[String], traitEfos: Rep[Seq[String]],
+//                   pubId: Rep[Option[String]], pubDate: Rep[Option[String]], pubJournal: Rep[Option[String]], pubTitle: Rep[Option[String]],
+//                   pubAuthor: Rep[Option[String]], ancestryInitial: Rep[Seq[String]], ancestryReplication: Rep[Seq[String]],
+//                   nInitial: Rep[Option[Long]], nReplication: Rep[Option[Long]], nCases: Rep[Option[Long]],
+//                   traitCategory: Rep[Option[String]])
 
   class Studies(tag: Tag) extends Table[Study](tag, "studies") {
     def studyId = column[String]("study_id")
@@ -99,6 +107,106 @@ object FRM {
   }
 
   lazy val studies = TableQuery[Studies]
+
+  // --------------------------------------------------------
+  // V2D
+
+//  case class V2D(
+//                  tagId: String, tagChromosome: String, tagPosition: Long, tagRefAllele: String, tagAltAllele: String, tagRsId: Option[String],
+//                  leadId: String, leadChromosome: String, leadPosition: Long, leadRefAllele: String, leadAltAllele: String, leadRsId: Option[String],
+//
+//                  studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
+//                 pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
+//                 pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
+//                 nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
+//                 traitCategory: Option[String],
+//
+//                   pval: Option[Double], r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
+//                  afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
+//                )
+  case class V2DAssociation(
+                      pval: Option[Double], r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
+                      afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
+                    )
+//  case class LiftedV2DAssociation(
+//                             pval: Rep[Option[Double]], r2: Rep[Option[Double]], log10Abf: Rep[Option[Double]], posteriorProbability: Rep[Option[Double]],
+//                             afr1000GProp: Rep[Option[Double]], amr1000GProp: Rep[Option[Double]], eas1000GProp: Rep[Option[Double]], eur1000GProp: Rep[Option[Double]], sas1000GProp: Rep[Option[Double]]
+//                           )
+  case class V2D(tag: SimpleVariant, lead: SimpleVariant, study: Study, association: V2DAssociation)
+//  case class LiftedV2D(tag: LiftedVariant, lead: LiftedVariant, study: LiftedStudy, association: LiftedV2DAssociation)
+//  implicit object V2DShape extends CaseClassShape(LiftedV2D.tupled, V2D.tupled)
+
+  class V2Ds(tag: Tag) extends Table[V2D](tag, "d2v2g") {
+    def tagId = column[String]("variant_id")
+    def tagChromosome = column[String]("chr_id")
+    def tagPosition = column[Long]("position")
+    def tagRefAllele = column[String]("ref_allele")
+    def tagAltAllele = column[String]("alt_allele")
+    def tagRsId = column[Option[String]]("rs_id")
+
+    def leadId = column[String]("index_variant_id")
+    def leadChromosome = column[String]("index_chr_id")
+    def leadPosition = column[Long]("index_position")
+    def leadRefAllele = column[String]("index_ref_allele")
+    def leadAltAllele = column[String]("index_alt_allele")
+    def leadRsId = column[Option[String]]("index_rs_id")
+
+    def studyId = column[String]("stid")
+    def traitCode = column[String]("trait_code")
+    def traitReported = column[String]("trait_reported")
+    def traitEfos = column[Seq[String]]("trait_efos")
+    def pubId = column[Option[String]]("pmid")
+    def pubDate = column[Option[String]]("pub_data")
+    def pubJournal = column[Option[String]]("pub_journal")
+    def pubTitle = column[Option[String]]("pub_title")
+    def pubAuthor = column[Option[String]]("pub_author")
+    def ancestryInitial = column[Seq[String]]("ancestry_initial")
+    def ancestryReplication = column[Seq[String]]("ancestry_replication")
+    def nInitial = column[Option[Long]]("n_initial")
+    def nReplication = column[Option[Long]]("n_replication")
+    def nCases = column[Option[Long]]("n_cases")
+    def traitCategory = column[Option[String]]("trait_category")
+
+    def pval = column[Option[Double]]("pval")
+    def r2 = column[Option[Double]]("r2")
+    def log10Abf = column[Option[Double]]("log10_abf")
+    def posteriorProbability = column[Option[Double]]("posterior_prob")
+
+    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
+    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
+    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
+    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
+    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
+
+    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
+    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
+    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
+
+    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
+//    def * = LiftedV2D(
+//      LiftedVariant(tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId),
+//      LiftedVariant(leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId),
+//      LiftedStudy(studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+//              pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory),
+//      LiftedV2DAssociation(pval, r2, log10Abf, posteriorProbability,
+//              afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp)
+//    )
+//    def * = (
+//      tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId,
+//      leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId,
+//      studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
+//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory,
+//      pval, r2, log10Abf, posteriorProbability,
+//      afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp
+//    ) <> (V2D.tupled, V2D.unapply)
+  }
+
+  lazy val v2Ds = TableQuery[V2Ds]
+
+  // --------------------------------------------------------
+
 
 //  // --------------------------------------------------------
 //  // V2D_BY_CHRPOS

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -1,8 +1,6 @@
 package models
 
-import models.Entities.TagVariantAssociation
 import slick.jdbc.H2Profile.api._
-import slick.lifted.MappedProjection
 
 object FRM {
   /**  In order to convert the db's string representation to Seq[Long] for the exons
@@ -52,20 +50,8 @@ object FRM {
   // --------------------------------------------------------
   // VARIANT
 
-//  case class SimpleVariant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String])
   case class Variant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
                      nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None)
-//  object Variant {
-////    def apply(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
-////      nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None): Variant = new Variant(id, chromosome, position, refAllele, altAllele, rsId,
-////      nearestGeneId, nearestCodingGeneId)
-////    def apply(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String]): Variant = new Variant(id, chromosome, position, refAllele, altAllele, rsId,)
-////    def unapply(v: Variant) = (v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId, v.nearestGeneId, v.nearestCodingGeneId)
-////    def unapply(v: Variant) = (v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
-//  }
-//  def simpleToFullVariant(v: SimpleVariant): Variant = {
-//    Variant(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId, None, None)
-//  }
 
   class Variants(tag: Tag) extends Table[Variant](tag, "variants") {
     def id = column[String]("variant_id")
@@ -117,134 +103,11 @@ object FRM {
   // --------------------------------------------------------
   // V2D
 
-//  case class V2D(
-//                  tagId: String, tagChromosome: String, tagPosition: Long, tagRefAllele: String, tagAltAllele: String, tagRsId: Option[String],
-//                  leadId: String, leadChromosome: String, leadPosition: Long, leadRefAllele: String, leadAltAllele: String, leadRsId: Option[String],
-//
-//                  studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
-//                 pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
-//                 pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
-//                 nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
-//                 traitCategory: Option[String],
-//
-//                   pval: Option[Double], r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
-//                  afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
-//                )
   case class V2DAssociation(
                       pval: Double, r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
                       afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
                     )
-//  case class LiftedV2DAssociation(
-//                             pval: Rep[Option[Double]], r2: Rep[Option[Double]], log10Abf: Rep[Option[Double]], posteriorProbability: Rep[Option[Double]],
-//                             afr1000GProp: Rep[Option[Double]], amr1000GProp: Rep[Option[Double]], eas1000GProp: Rep[Option[Double]], eur1000GProp: Rep[Option[Double]], sas1000GProp: Rep[Option[Double]]
-//                           )
   case class V2D(tag: Variant, lead: Variant, study: Study, association: V2DAssociation)
-//  case class LiftedV2D(tag: LiftedVariant, lead: LiftedVariant, study: LiftedStudy, association: LiftedV2DAssociation)
-//  implicit object V2DShape extends CaseClassShape(LiftedV2D.tupled, V2D.tupled)
-
-//  trait V2DFields {
-//    def tagId = column[String]("variant_id")
-//    def tagChromosome = column[String]("chr_id")
-//    def tagPosition = column[Long]("position")
-//    def tagRefAllele = column[String]("ref_allele")
-//    def tagAltAllele = column[String]("alt_allele")
-//    def tagRsId = column[Option[String]]("rs_id")
-//
-//    def leadId = column[String]("index_variant_id")
-//    def leadChromosome = column[String]("index_chr_id")
-//    def leadPosition = column[Long]("index_position")
-//    def leadRefAllele = column[String]("index_ref_allele")
-//    def leadAltAllele = column[String]("index_alt_allele")
-//    def leadRsId = column[Option[String]]("index_rs_id")
-//
-//    def studyId = column[String]("stid")
-//    def traitCode = column[String]("trait_code")
-//    def traitReported = column[String]("trait_reported")
-//    def traitEfos = column[Seq[String]]("trait_efos")
-//    def pubId = column[Option[String]]("pmid")
-//    def pubDate = column[Option[String]]("pub_data")
-//    def pubJournal = column[Option[String]]("pub_journal")
-//    def pubTitle = column[Option[String]]("pub_title")
-//    def pubAuthor = column[Option[String]]("pub_author")
-//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
-//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
-//    def nInitial = column[Option[Long]]("n_initial")
-//    def nReplication = column[Option[Long]]("n_replication")
-//    def nCases = column[Option[Long]]("n_cases")
-//    def traitCategory = column[Option[String]]("trait_category")
-//
-//    def pval = column[Option[Double]]("pval")
-//    def r2 = column[Option[Double]]("r2")
-//    def log10Abf = column[Option[Double]]("log10_abf")
-//    def posteriorProbability = column[Option[Double]]("posterior_prob")
-//
-//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
-//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
-//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
-//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
-//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
-//
-//    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
-//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
-//    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
-//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
-//    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
-//
-//    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
-//  }
-
-//  class V2DsByStudy(tag: Tag) extends Table[V2D](tag, "v2d_by_stchr") {
-//    def tagId = column[String]("variant_id")
-//    def tagChromosome = column[String]("chr_id")
-//    def tagPosition = column[Long]("position")
-//    def tagRefAllele = column[String]("ref_allele")
-//    def tagAltAllele = column[String]("alt_allele")
-//    def tagRsId = column[Option[String]]("rs_id")
-//
-//    def leadId = column[String]("index_variant_id")
-//    def leadChromosome = column[String]("index_chr_id")
-//    def leadPosition = column[Long]("index_position")
-//    def leadRefAllele = column[String]("index_ref_allele")
-//    def leadAltAllele = column[String]("index_alt_allele")
-//    def leadRsId = column[Option[String]]("index_rs_id")
-//
-//    def studyId = column[String]("stid")
-//    def traitCode = column[String]("trait_code")
-//    def traitReported = column[String]("trait_reported")
-//    def traitEfos = column[Seq[String]]("trait_efos")
-//    def pubId = column[Option[String]]("pmid")
-//    def pubDate = column[Option[String]]("pub_data")
-//    def pubJournal = column[Option[String]]("pub_journal")
-//    def pubTitle = column[Option[String]]("pub_title")
-//    def pubAuthor = column[Option[String]]("pub_author")
-//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
-//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
-//    def nInitial = column[Option[Long]]("n_initial")
-//    def nReplication = column[Option[Long]]("n_replication")
-//    def nCases = column[Option[Long]]("n_cases")
-//    def traitCategory = column[Option[String]]("trait_category")
-//
-//    def pval = column[Double]("pval")
-//    def r2 = column[Option[Double]]("r2")
-//    def log10Abf = column[Option[Double]]("log10_abf")
-//    def posteriorProbability = column[Option[Double]]("posterior_prob")
-//
-//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
-//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
-//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
-//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
-//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
-//
-//    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
-//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
-//    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
-//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
-//    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
-//    def nTotal = nInitial.getOrElse(0) + nReplication.getOrElse(0)
-//
-//    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
-//  }
-//  lazy val v2DsByStudy = TableQuery[V2DsByStudy]
 
   def tupleToVariant (t: Tuple6[String, String, Long, String, String, Option[String]]) = Variant(t._1, t._2, t._3, t._4, t._5, t._6)
   def variantToTuple (v: Variant) = Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
@@ -292,89 +155,15 @@ object FRM {
     def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
     def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
 
-//    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (t => Variant(t._1, t._2, t._3, t._4, t._5, t._6), (v: Variant) => Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId))
     def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (tupleToVariant, variantToTuple)
-//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (SimpleVariant.tupled, SimpleVariant.unapply)
     def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (tupleToVariant, variantToTuple)
-    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
-      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
+    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle, pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
     def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
-
-//    def nTotal = nInitial.getOrElse(0) + nReplication.getOrElse(0)
-//    def asTagVariantAssociation = TagVariantAssociation(
-//      leadProjection, studyId, pval, nTotal, nCases.getOrElse(0),
-//      r2, afr1000GProp, amr1000GProp, eas1000GProp,
-//      eur1000GProp, sas1000GProp, log10Abf, posteriorProbability
-//    )
-//    def tagVariantAssociationProjection = (
-//      leadProjection, studyId, pval, nInitial.getOrElse(0) + nReplication.getOrElse(0), nCases.getOrElse(0),
-//      r2, afr1000GProp, amr1000GProp, eas1000GProp,
-//      eur1000GProp, sas1000GProp, log10Abf, posteriorProbability
-//    ) <> (TagVariantAssociation.tupled, TagVariantAssociation.unapply)
 
     def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
   }
+
   lazy val v2DsByChrPos = TableQuery[V2DsByChrPos]
 
-  // --------------------------------------------------------
-
-
-//  // --------------------------------------------------------
-//  // V2D_BY_CHRPOS
-//
-//  case class V2D(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
-//                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
-//                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
-//                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
-//                   traitCategory: Option[String])
-//
-//  class V2DsByChrPos(tag: Tag) extends Table[V2D](tag, "v2d_by_chrpos") {
-//    def tagId = column[String]("variant_id")
-//    def tagChromosome = column[String]("chr_id")
-//    def tagPosition = column[Long]("position")
-//    def tagRefAllele = column[String]("ref_allele")
-//    def tagAltAllele = column[String]("alt_allele")
-//    def tagRsId = column[Option[String]]("rs_id")
-//    def leadId = column[String]("index_variant_id")
-//    def leadChromosome = column[String]("index_chr_id")
-//    def leadPosition = column[Long]("index_position")
-//    def leadRefAllele = column[String]("index_ref_allele")
-//    def leadAltAllele = column[String]("index_alt_allele")
-//    def leadRsId = column[Option[String]]("index_rs_id")
-//
-//    def studyId = column[String]("stid")
-//    def pval = column[Option[Double]]("pval")
-//    def r2 = column[Option[Double]]("r2")
-//    def log10Abf = column[Option[Double]]("log10_abf")
-//    def posteriorProbability = column[Option[Double]]("posterior_prob")
-//
-//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
-//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
-//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
-//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
-//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
-//
-//    def traitCode = column[String]("trait_code")
-//    def traitReported = column[String]("trait_reported")
-//    def traitEfos = column[Seq[String]]("trait_efos")
-//    def pubId = column[Option[String]]("pmid")
-//    def pubDate = column[Option[String]]("pub_data")
-//    def pubJournal = column[Option[String]]("pub_journal")
-//    def pubTitle = column[Option[String]]("pub_title")
-//    def pubAuthor = column[Option[String]]("pub_author")
-//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
-//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
-//    def nInitial = column[Option[Long]]("n_initial")
-//    def nReplication = column[Option[Long]]("n_replication")
-//    def nCases = column[Option[Long]]("n_cases")
-//    def traitCategory = column[Option[String]]("trait_category")
-//    def * = (
-//      studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle,
-//      pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory
-//    ) <> (Study.tupled, Study.unapply)
-//  }
-//
-//  lazy val v2DsByChrPos = TableQuery[V2DsByChrPos]
-//
 //  // --------------------------------------------------------
 }

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -1,33 +1,28 @@
 package models
 
-import slick.jdbc.H2Profile.api._
+import clickhouse.ClickHouseProfile
+import clickhouse.rep.SeqRep.{DSeqRep, LSeqRep, StrSeqRep}
+import clickhouse.rep.SeqRep.Implicits._
+import DNA.{Variant, Gene}
+import Entities.Study
 
 object FRM {
-  /**  In order to convert the db's string representation to Seq[Long] for the exons
-    *  the sql approach can use `cast(exons, 'Array(UInt32)') AS exons`, which might
-    *  be achievable with a SimpleExpression. Alternatively (and working), there is
-    *  a MappedColumnType, which likely does the conversion in scala.
-    */
+  import clickhouse.ClickHouseProfile.api._
 
-  implicit val seqLongType = MappedColumnType.base[Seq[Long], String](
-    { ls => ls.mkString("[", ",", "]") },
-    { s => s.filterNot("[]".toSet).split(",").map(_.toLong).toSeq }
-  )
-  implicit val seqDoubleType = MappedColumnType.base[Seq[Double], String](
-    { ls => ls.mkString("[", ",", "]") },
-    { s => s.filterNot("[]".toSet).split(",").map(_.toDouble).toSeq }
-  )
-  implicit val seqStringType = MappedColumnType.base[Seq[String], String](
-    { ss => ss.map("'" + _ + "'").mkString("[", ",", "]") },
-    { s => s.filterNot("[]".toSet).split(",").toSeq }
-  )
+  /** Clickhouse driver allows us to get serialised Arrays of all scalar types. But
+    * jdbc does not allows to map to a seq of a scalar so this columns are defined here to
+    * be able to interpret them implicitily. It is worth noting these functions can be
+    * moved into the slick driver for clickhouse
+    */
+  implicit val seqLongType: ClickHouseProfile.BaseColumnType[Seq[Long]] =
+    MappedColumnType.base[Seq[Long], String](_.mkString("[", ",", "]"), LSeqRep(_))
+  implicit val seqDoubleType: ClickHouseProfile.BaseColumnType[Seq[Double]] =
+    MappedColumnType.base[Seq[Double], String](_.mkString("[", ",", "]"), DSeqRep(_))
+  implicit val seqStringType: ClickHouseProfile.BaseColumnType[Seq[String]] =
+    MappedColumnType.base[Seq[String], String](_.map("'" + _ + "'").mkString("[", ",", "]"), StrSeqRep(_))
 
   // --------------------------------------------------------
   // GENE
-
-  case class Gene(id: String, symbol: Option[String], bioType: Option[String] = None, chromosome: Option[String] = None,
-                  tss: Option[Long] = None, start: Option[Long] = None, end: Option[Long] = None,
-                  fwd: Option[Boolean] = None, exons: Seq[Long] = Seq.empty)
 
   class Genes(tag: Tag) extends Table[Gene](tag, "gene") {
     def id = column[String]("gene_id")
@@ -39,16 +34,12 @@ object FRM {
     def end = column[Option[Long]]("end")
     def fwd = column[Option[Boolean]]("fwdstrand")
     def exons = column[Seq[Long]]("exons")
-    def * = (id, symbol, bioType, chromosome, tss, start, end, fwd, exons) <> (Gene.tupled, Gene.unapply)
+    def * = (id, symbol, bioType, chromosome, tss, start, end, fwd, exons) <>
+      (Gene.tupled, Gene.unapply)
   }
-
-  lazy val genes = TableQuery[Genes]
 
   // --------------------------------------------------------
   // VARIANT
-
-  case class Variant(id: String, chromosome: String, position: Long, refAllele: String, altAllele: String, rsId: Option[String],
-                     nearestGeneId: Option[String] = None, nearestCodingGeneId: Option[String] = None)
 
   class Variants(tag: Tag) extends Table[Variant](tag, "variants") {
     def id = column[String]("variant_id")
@@ -59,19 +50,12 @@ object FRM {
     def rsId = column[Option[String]]("rs_id")
     def nearestGeneId = column[Option[String]]("gene_id")
     def nearestCodingGeneId = column[Option[String]]("gene_id_prot_coding")
-    def * = (id, chromosome, position, refAllele, altAllele, rsId, nearestGeneId, nearestCodingGeneId) <> (Variant.tupled, Variant.unapply)
+    def * = (id, chromosome, position, refAllele, altAllele, rsId, nearestGeneId, nearestCodingGeneId) <>
+      (Variant.tupled, Variant.unapply)
   }
-
-  lazy val variants = TableQuery[Variants]
 
   // --------------------------------------------------------
   // STUDY
-
-  case class Study(studyId: String, traitCode: String, traitReported: String, traitEfos: Seq[String],
-                   pubId: Option[String], pubDate: Option[String], pubJournal: Option[String], pubTitle: Option[String],
-                   pubAuthor: Option[String], ancestryInitial: Seq[String], ancestryReplication: Seq[String],
-                   nInitial: Option[Long], nReplication: Option[Long], nCases: Option[Long],
-                   traitCategory: Option[String])
 
   class Studies(tag: Tag) extends Table[Study](tag, "studies") {
     def studyId = column[String]("study_id")
@@ -95,83 +79,73 @@ object FRM {
     ) <> (Study.tupled, Study.unapply)
   }
 
-  lazy val studies = TableQuery[Studies]
+  //  // V2D (NOT CURRENTLY USED)
+  //  // --------------------------------------------------------
 
-  // --------------------------------------------------------
-  // V2D (NOT CURRENTLY USED)
-
-  case class V2DAssociation(
-                      pval: Double, r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],
-                      afr1000GProp: Option[Double], amr1000GProp: Option[Double], eas1000GProp: Option[Double], eur1000GProp: Option[Double], sas1000GProp: Option[Double]
-                    )
-  case class V2D(tag: Variant, lead: Variant, study: Study, association: V2DAssociation)
-
-  def tupleToVariant (t: Tuple6[String, String, Long, String, String, Option[String]]) = Variant(t._1, t._2, t._3, t._4, t._5, t._6)
-  def variantToTuple (v: Variant) = Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
-
-  trait TagVariantFields extends Table[V2D] {
-    def tagId = column[String]("variant_id")
-    def tagChromosome = column[String]("chr_id")
-    def tagPosition = column[Long]("position")
-    def tagRefAllele = column[String]("ref_allele")
-    def tagAltAllele = column[String]("alt_allele")
-    def tagRsId = column[Option[String]]("rs_id")
-    def tagProjection = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <> (tupleToVariant, variantToTuple)
-  }
-
-  trait LeadVariantFields extends Table[V2D] {
-    def leadId = column[String]("index_variant_id")
-    def leadChromosome = column[String]("index_chr_id")
-    def leadPosition = column[Long]("index_position")
-    def leadRefAllele = column[String]("index_ref_allele")
-    def leadAltAllele = column[String]("index_alt_allele")
-    def leadRsId = column[Option[String]]("index_rs_id")
-    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (tupleToVariant, variantToTuple)
-  }
-
-  trait StudyFields extends Table[V2D] {
-    def studyId = column[String]("stid")
-    def traitCode = column[String]("trait_code")
-    def traitReported = column[String]("trait_reported")
-    def traitEfos = column[Seq[String]]("trait_efos")
-    def pubId = column[Option[String]]("pmid")
-    def pubDate = column[Option[String]]("pub_date")
-    def pubJournal = column[Option[String]]("pub_journal")
-    def pubTitle = column[Option[String]]("pub_title")
-    def pubAuthor = column[Option[String]]("pub_author")
-    def ancestryInitial = column[Seq[String]]("ancestry_initial")
-    def ancestryReplication = column[Seq[String]]("ancestry_replication")
-    def nInitial = column[Option[Long]]("n_initial")
-    def nReplication = column[Option[Long]]("n_replication")
-    def nCases = column[Option[Long]]("n_cases")
-    def traitCategory = column[Option[String]]("trait_category")
-    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle, pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
-  }
-
-  trait V2DAssociationFields extends Table[V2D] {
-    def pval = column[Double]("pval")
-    def r2 = column[Option[Double]]("r2")
-    def log10Abf = column[Option[Double]]("log10_abf")
-    def posteriorProbability = column[Option[Double]]("posterior_prob")
-
-    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
-    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
-    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
-    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
-    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
-    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
-  }
-
-  class V2DsByChrPos(tag: Tag) extends Table[V2D](tag, "v2d_by_chrpos") with TagVariantFields with LeadVariantFields with StudyFields with V2DAssociationFields {
-    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
-  }
-
-  lazy val v2DsByChrPos = TableQuery[V2DsByChrPos]
-
-  class V2DsByStudy(tag: Tag) extends Table[V2D](tag, "v2d_by_stchr") with TagVariantFields with LeadVariantFields with StudyFields with V2DAssociationFields {
-    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
-  }
-
-  lazy val v2DsByStudy = TableQuery[V2DsByChrPos]
-
+//  case class V2D(tag: Variant, lead: Variant, study: Study, association: V2DAssociation)
+//
+//  // def tupleToVariant (t: Tuple6[_, String, Long, String, String, Option[String]]) = Variant(t._2, t._3, t._4, t._5, t._6)
+//  // def variantToTuple (v: Variant) = Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
+//
+//  trait TagVariantFields extends Table[V2D] {
+//    def tagId = column[String]("variant_id")
+//    def tagChromosome = column[String]("chr_id")
+//    def tagPosition = column[Long]("position")
+//    def tagRefAllele = column[String]("ref_allele")
+//    def tagAltAllele = column[String]("alt_allele")
+//    def tagRsId = column[Option[String]]("rs_id")
+//    def `*`: ProvenShape[Variant] = (tagId, tagChromosome, tagPosition, tagRefAllele, tagAltAllele, tagRsId) <>
+//      (Variant.tupled, Variant.unapply)
+//  }
+//
+//  trait LeadVariantFields extends Table[V2D] {
+//    def leadId = column[String]("index_variant_id")
+//    def leadChromosome = column[String]("index_chr_id")
+//    def leadPosition = column[Long]("index_position")
+//    def leadRefAllele = column[String]("index_ref_allele")
+//    def leadAltAllele = column[String]("index_alt_allele")
+//    def leadRsId = column[Option[String]]("index_rs_id")
+//    def leadProjection = (leadId, leadChromosome, leadPosition, leadRefAllele, leadAltAllele, leadRsId) <> (tupleToVariant, variantToTuple)
+//  }
+//
+//  trait StudyFields extends Table[V2D] {
+//    def studyId = column[String]("stid")
+//    def traitCode = column[String]("trait_code")
+//    def traitReported = column[String]("trait_reported")
+//    def traitEfos = column[Seq[String]]("trait_efos")
+//    def pubId = column[Option[String]]("pmid")
+//    def pubDate = column[Option[String]]("pub_date")
+//    def pubJournal = column[Option[String]]("pub_journal")
+//    def pubTitle = column[Option[String]]("pub_title")
+//    def pubAuthor = column[Option[String]]("pub_author")
+//    def ancestryInitial = column[Seq[String]]("ancestry_initial")
+//    def ancestryReplication = column[Seq[String]]("ancestry_replication")
+//    def nInitial = column[Option[Long]]("n_initial")
+//    def nReplication = column[Option[Long]]("n_replication")
+//    def nCases = column[Option[Long]]("n_cases")
+//    def traitCategory = column[Option[String]]("trait_category")
+//    def studyProjection = (studyId, traitCode, traitReported, traitEfos, pubId, pubDate, pubJournal, pubTitle, pubAuthor, ancestryInitial, ancestryReplication, nInitial, nReplication, nCases, traitCategory) <> (Study.tupled, Study.unapply)
+//  }
+//
+//  trait V2DAssociationFields extends Table[V2D] {
+//    def pval = column[Double]("pval")
+//    def r2 = column[Option[Double]]("r2")
+//    def log10Abf = column[Option[Double]]("log10_abf")
+//    def posteriorProbability = column[Option[Double]]("posterior_prob")
+//
+//    def afr1000GProp = column[Option[Double]]("afr_1000g_prop")
+//    def amr1000GProp = column[Option[Double]]("amr_1000g_prop")
+//    def eas1000GProp = column[Option[Double]]("eas_1000g_prop")
+//    def eur1000GProp = column[Option[Double]]("eur_1000g_prop")
+//    def sas1000GProp = column[Option[Double]]("sas_1000g_prop")
+//    def associationProjection = (pval, r2, log10Abf, posteriorProbability, afr1000GProp, amr1000GProp, eas1000GProp, eur1000GProp, sas1000GProp) <> (V2DAssociation.tupled, V2DAssociation.unapply)
+//  }
+//
+//  class V2DsByChrPos(tag: Tag) extends Table[V2D](tag, "v2d_by_chrpos") with TagVariantFields with LeadVariantFields with StudyFields with V2DAssociationFields {
+//    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
+//  }
+//
+//  class V2DsByStudy(tag: Tag) extends Table[V2D](tag, "v2d_by_stchr") with TagVariantFields with LeadVariantFields with StudyFields with V2DAssociationFields {
+//    def * = (tagProjection, leadProjection, studyProjection, associationProjection) <> (V2D.tupled, V2D.unapply)
+//  }
 }

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -98,7 +98,7 @@ object FRM {
   lazy val studies = TableQuery[Studies]
 
   // --------------------------------------------------------
-  // V2D
+  // V2D (NOT CURRENTLY USED)
 
   case class V2DAssociation(
                       pval: Double, r2: Option[Double], log10Abf: Option[Double], posteriorProbability: Option[Double],

--- a/app/models/FRM.scala
+++ b/app/models/FRM.scala
@@ -250,6 +250,7 @@ object FRM {
   def variantToTuple (v: Variant) = Some(v.id, v.chromosome, v.position, v.refAllele, v.altAllele, v.rsId)
 
   class V2DsByChrPos(tag: Tag) extends Table[V2D](tag, "v2d_by_chrpos") {
+    // TODO: Factor out common column groups for reuse
     def tagId = column[String]("variant_id")
     def tagChromosome = column[String]("chr_id")
     def tagPosition = column[Long]("position")
@@ -269,7 +270,7 @@ object FRM {
     def traitReported = column[String]("trait_reported")
     def traitEfos = column[Seq[String]]("trait_efos")
     def pubId = column[Option[String]]("pmid")
-    def pubDate = column[Option[String]]("pub_data")
+    def pubDate = column[Option[String]]("pub_date")
     def pubJournal = column[Option[String]]("pub_journal")
     def pubTitle = column[Option[String]]("pub_title")
     def pubAuthor = column[Option[String]]("pub_author")

--- a/app/models/Functions.scala
+++ b/app/models/Functions.scala
@@ -2,8 +2,6 @@ package models
 
 import models.Violations.{ChromosomeViolation, InChromosomeRegionViolation}
 
-import reflect.runtime.universe._
-
 object Functions {
   val defaultPaginationSize: Option[Int] = Some(500000)
   val defaultPaginationSizeES: Option[Int] = Some(10)

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -486,45 +486,45 @@ object GQLSchema {
         resolve = _.value.associations)
     ))
 
-//  val tissue = ObjectType("Tissue",
-//    "",
-//    fields[Backend, Tissue](
-//      Field("id", StringType,
-//        Some(""),
-//        resolve = _.value.id),
-//      Field("name", OptionType(StringType),
-//        Some(""),
-//        resolve = _.value.name)
-//    ))
-//
-//  val g2vSchemaElement = ObjectType("G2VSchemaElement",
-//    "A list of rows with each link",
-//    fields[Backend, G2VSchemaElement](
-//      Field("id", StringType,
-//        Some(""),
-//        resolve = _.value.id),
-//      Field("sourceId", StringType,
-//        Some(""),
-//        resolve = _.value.sourceId),
-//      Field("tissues", ListType(tissue),
-//        Some(""),
-//        resolve = _.value.tissues)
-//    ))
-//
-//  val v2gSchema = ObjectType("G2VSchema",
-//    "A list of rows with each link",
-//    fields[Backend, G2VSchema](
-//      Field("qtls", ListType(g2vSchemaElement),
-//        Some("qtl structure definition"),
-//        resolve = _.value.qtls),
-//      Field("intervals", ListType(g2vSchemaElement),
-//        Some("qtl structure definition"),
-//        resolve = _.value.intervals),
-//      Field("functionalPredictions", ListType(g2vSchemaElement),
-//        Some("qtl structure definition"),
-//        resolve = _.value.functionalPredictions)
-//    ))
-//
+  val tissue = ObjectType("Tissue",
+    "",
+    fields[Backend, Tissue](
+      Field("id", StringType,
+        Some(""),
+        resolve = _.value.id),
+      Field("name", OptionType(StringType),
+        Some(""),
+        resolve = _.value.name)
+    ))
+
+  val g2vSchemaElement = ObjectType("G2VSchemaElement",
+    "A list of rows with each link",
+    fields[Backend, G2VSchemaElement](
+      Field("id", StringType,
+        Some(""),
+        resolve = _.value.id),
+      Field("sourceId", StringType,
+        Some(""),
+        resolve = _.value.sourceId),
+      Field("tissues", ListType(tissue),
+        Some(""),
+        resolve = _.value.tissues)
+    ))
+
+  val v2gSchema = ObjectType("G2VSchema",
+    "A list of rows with each link",
+    fields[Backend, G2VSchema](
+      Field("qtls", ListType(g2vSchemaElement),
+        Some("qtl structure definition"),
+        resolve = _.value.qtls),
+      Field("intervals", ListType(g2vSchemaElement),
+        Some("qtl structure definition"),
+        resolve = _.value.intervals),
+      Field("functionalPredictions", ListType(g2vSchemaElement),
+        Some("qtl structure definition"),
+        resolve = _.value.functionalPredictions)
+    ))
+
 //  val qtlTissue = ObjectType("QTLTissue",
 //    "",
 //    fields[Backend, QTLTissue](
@@ -714,9 +714,9 @@ object GQLSchema {
 //      Field("gecko", OptionType(gecko),
 //        arguments = chromosome :: dnaPosStart :: dnaPosEnd :: Nil,
 //        resolve = ctx => ctx.ctx.buildGecko(ctx.arg(chromosome), ctx.arg(dnaPosStart), ctx.arg(dnaPosEnd))),
-//      Field("genesForVariantSchema", v2gSchema,
-//        arguments = Nil,
-//        resolve = ctx => ctx.ctx.getG2VSchema),
+      Field("genesForVariantSchema", v2gSchema,
+        arguments = Nil,
+        resolve = ctx => ctx.ctx.getG2VSchema),
 //      Field("genesForVariant", ListType(geneForVariant),
 //        arguments = variantId :: Nil,
 //        resolve = ctx => ctx.ctx.buildG2VByVariant(ctx.arg(variantId))),

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -1,14 +1,8 @@
 package models
 
-
 import sangria.execution.deferred._
 import sangria.schema._
 import Entities._
-import DNA.Variant
-//import FRM.Variant
-import sangria.schema
-import sangria.streaming.ValidOutStreamType
-import Entities.DBImplicits.frm2dnaVariant
 
 object GQLSchema {
   val studyId = Argument("studyId", StringType, description = "Study ID which links a top loci with a trait")

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -4,10 +4,11 @@ package models
 import sangria.execution.deferred._
 import sangria.schema._
 import Entities._
-import DNA.Variant
-import FRM.Gene
+//import DNA.Variant
+import FRM.Variant
 import sangria.schema
 import sangria.streaming.ValidOutStreamType
+//import Entities.DBImplicits.frm2gqlVariant
 
 object GQLSchema {
   val studyId = Argument("studyId", StringType, description = "Study ID which links a top loci with a trait")
@@ -23,10 +24,14 @@ object GQLSchema {
   val queryString = Argument("queryString", StringType, description = "Query text to search for")
 
   implicit val geneHasId = HasId[FRM.Gene, String](_.id)
+  implicit val variantHasId = HasId[FRM.Variant, String](_.id)
+  implicit val studyHasId = HasId[FRM.Study, String](_.studyId)
+
+
 
   val gene = ObjectType("Gene",
   "This element represents a simple gene object which contains id and name",
-    fields[Backend, Gene](
+    fields[Backend, FRM.Gene](
       Field("id", StringType,
         Some("Ensembl Gene ID of a gene"),
         resolve = _.value.id),
@@ -78,10 +83,10 @@ object GQLSchema {
         resolve = _.value.rsId),
       Field("chromosome", StringType,
         Some("Ensembl Gene ID of a gene"),
-        resolve = _.value.position.chrId),
+        resolve = _.value.chromosome),
       Field("position", LongType,
         Some("Approved symbol name of a gene"),
-        resolve = _.value.position.position),
+        resolve = _.value.position),
       Field("refAllele", StringType,
         Some("Ref allele"),
         resolve = _.value.refAllele),
@@ -122,7 +127,7 @@ object GQLSchema {
 
   val study = ObjectType("Study",
   "This element contains all study fields",
-    fields[Backend, Study](
+    fields[Backend, FRM.Study](
       Field("studyId", StringType,
         Some("Study Identifier"),
         resolve = _.value.studyId),
@@ -170,316 +175,316 @@ object GQLSchema {
         resolve = _.value.traitCategory)
     ))
 
-  val indexVariantAssociation = ObjectType("IndexVariantAssociation",
-    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
-      "via an expansion method (either ldExpansion or FineMapping)",
-    fields[Backend, IndexVariantAssociation](
-      Field("tagVariant", variant,
-        Some("Tag variant ID as ex. 1_12345_A_T"),
-        resolve = _.value.tagVariant),
-      Field("study", study,
-        Some("study ID"),
-        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
-      Field("pval", FloatType,
-        Some("p-val between a study and an the provided index variant"),
-        resolve = _.value.pval),
-      Field("nTotal", IntType,
-        Some("n total cases (n initial + n replication)"),
-        resolve = _.value.nTotal),
-      Field("nCases", IntType,
-        Some("n cases"),
-        resolve = _.value.nCases),
-      Field("overallR2", OptionType(FloatType),
-        Some("study ID"),
-        resolve = _.value.r2),
-      Field("afr1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.afr1000GProp),
-      Field("amr1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.amr1000GProp),
-      Field("eas1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.eas1000GProp),
-      Field("eur1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.eur1000GProp),
-      Field("sas1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.sas1000GProp),
-      Field("log10Abf", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.log10Abf),
-      Field("posteriorProbability", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.posteriorProbability)
-    ))
+//  val indexVariantAssociation = ObjectType("IndexVariantAssociation",
+//    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
+//      "via an expansion method (either ldExpansion or FineMapping)",
+//    fields[Backend, IndexVariantAssociation](
+//      Field("tagVariant", variant,
+//        Some("Tag variant ID as ex. 1_12345_A_T"),
+//        resolve = _.value.tagVariant),
+//      Field("study", study,
+//        Some("study ID"),
+//        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
+//      Field("pval", FloatType,
+//        Some("p-val between a study and an the provided index variant"),
+//        resolve = _.value.pval),
+//      Field("nTotal", IntType,
+//        Some("n total cases (n initial + n replication)"),
+//        resolve = _.value.nTotal),
+//      Field("nCases", IntType,
+//        Some("n cases"),
+//        resolve = _.value.nCases),
+//      Field("overallR2", OptionType(FloatType),
+//        Some("study ID"),
+//        resolve = _.value.r2),
+//      Field("afr1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.afr1000GProp),
+//      Field("amr1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.amr1000GProp),
+//      Field("eas1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.eas1000GProp),
+//      Field("eur1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.eur1000GProp),
+//      Field("sas1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.sas1000GProp),
+//      Field("log10Abf", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.log10Abf),
+//      Field("posteriorProbability", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.posteriorProbability)
+//    ))
 
-  val tagVariantAssociation = ObjectType("TagVariantAssociation",
-    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
-      "via an expansion method (either ldExpansion or FineMapping)",
-    fields[Backend, TagVariantAssociation](
-      Field("indexVariant", variant,
-        Some("Tag variant ID as ex. 1_12345_A_T"),
-        resolve = _.value.indexVariant),
-      Field("study", study,
-        Some("study ID"),
-        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
-      Field("pval", FloatType,
-        Some("p-val between a study and an the provided index variant"),
-        resolve = _.value.pval),
-      Field("nTotal", IntType,
-        Some("n total cases (n initial + n replication)"),
-        resolve = _.value.nTotal),
-      Field("nCases", IntType,
-        Some("n cases"),
-        resolve = _.value.nCases),
-      Field("overallR2", OptionType(FloatType),
-        Some("study ID"),
-        resolve = _.value.r2),
-      Field("afr1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.afr1000GProp),
-      Field("amr1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.amr1000GProp),
-      Field("eas1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.eas1000GProp),
-      Field("eur1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.eur1000GProp),
-      Field("sas1000GProp", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.sas1000GProp),
-      Field("log10Abf", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.log10Abf),
-      Field("posteriorProbability", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.posteriorProbability)
-    ))
+//  val tagVariantAssociation = ObjectType("TagVariantAssociation",
+//    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
+//      "via an expansion method (either ldExpansion or FineMapping)",
+//    fields[Backend, TagVariantAssociation](
+//      Field("indexVariant", variant,
+//        Some("Tag variant ID as ex. 1_12345_A_T"),
+//        resolve = _.value.indexVariant),
+//      Field("study", study,
+//        Some("study ID"),
+//        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
+//      Field("pval", FloatType,
+//        Some("p-val between a study and an the provided index variant"),
+//        resolve = _.value.pval),
+//      Field("nTotal", IntType,
+//        Some("n total cases (n initial + n replication)"),
+//        resolve = _.value.nTotal),
+//      Field("nCases", IntType,
+//        Some("n cases"),
+//        resolve = _.value.nCases),
+//      Field("overallR2", OptionType(FloatType),
+//        Some("study ID"),
+//        resolve = _.value.r2),
+//      Field("afr1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.afr1000GProp),
+//      Field("amr1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.amr1000GProp),
+//      Field("eas1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.eas1000GProp),
+//      Field("eur1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.eur1000GProp),
+//      Field("sas1000GProp", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.sas1000GProp),
+//      Field("log10Abf", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.log10Abf),
+//      Field("posteriorProbability", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.posteriorProbability)
+//    ))
 
-  val manhattanAssociation = ObjectType("ManhattanAssociation",
-  "This element represents an association between a trait and a variant through a study",
-    fields[Backend, ManhattanAssociation](
-      Field("variant", variant,
-        Some("Index variant"),
-        resolve = r => variantsFetcher.defer(r.value.variantId)),
-      Field("pval", FloatType,
-        Some("Computed p-Value"),
-        resolve = _.value.pval),
-      Field("bestGenes", ListType(scoredGene),
-        Some("A list of best genes associated"),
-        resolve = _.value.bestGenes),
-      Field("credibleSetSize", OptionType(LongType),
-      Some("The cardinal of the set defined as tag variants for an index variant coming from crediblesets"),
-        resolve = _.value.crediblbeSetSize),
-      Field("ldSetSize", OptionType(LongType),
-        Some("The cardinal of the set defined as tag variants for an index variant coming from ld expansion"),
-        resolve = _.value.ldSetSize),
-      Field("totalSetSize", LongType,
-        Some("The cardinal of the set defined as tag variants for an index variant coming from any expansion"),
-        resolve = _.value.totalSetSize)
-    ))
-
-
-  val pheWASAssociation = ObjectType("PheWASAssociation",
-    "This element represents an association between a variant and a reported trait through a study",
-    fields[Backend, VariantPheWAS](
-      Field("study", OptionType(study),
-        Some("Study Object"),
-        resolve = rsl => studiesFetcher.deferOpt(rsl.value.stid)),
-      Field("pval", FloatType,
-        Some("Computed p-Value"),
-        resolve = _.value.pval),
-      Field("beta", FloatType,
-        Some("beta"),
-        resolve = _.value.beta),
-      Field("nTotal", OptionType(LongType),
-        Some("total sample size (variant level)"),
-        resolve = _.value.nSamplesVariant),
-      Field("nCases", OptionType(LongType),
-        Some("number of cases (variant level)"),
-        resolve = _.value.nCasesVariant),
-      Field("nTotalStudy", OptionType(LongType),
-        Some("total sample size (study level, available when variant level is not provided)"),
-        resolve = _.value.nSamplesStudy),
-      Field("nCasesStudy", OptionType(LongType),
-        Some("number of cases (study level, available when variant level is not provided)"),
-        resolve = _.value.nCasesStudy),
-      Field("oddsRatio", OptionType(FloatType),
-        Some("Odds ratio (if case control)"),
-        resolve = _.value.oddRatio),
-      Field("chip", StringType,
-        Some("Chip type: 'metabochip' 'inmunochip', 'genome wide'"),
-        resolve = _.value.chip),
-      Field("info", OptionType(FloatType),
-        Some("Info"),
-        resolve = _.value.info)
-    ))
-
-  val geneTagVariant = ObjectType("GeneTagVariant",
-    "",
-    fields[Backend, GeneTagVariant](
-      Field("geneId", StringType,
-        Some(""),
-        resolve = _.value.geneId),
-      Field("tagVariantId", StringType,
-        Some(""),
-        resolve = _.value.tagVariantId),
-      Field("overallScore", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.overallScore)
-    ))
-
-  val tagVariantIndexVariantStudy = ObjectType("TagVariantIndexVariantStudy",
-    "",
-    fields[Backend, TagVariantIndexVariantStudy](
-      Field("tagVariantId", StringType,
-        Some(""),
-        resolve = _.value.tagVariantId),
-      Field("indexVariantId", StringType,
-        Some(""),
-        resolve = _.value.indexVariantId),
-      Field("studyId", StringType,
-        Some(""),
-        resolve = _.value.studyId),
-      Field("r2", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.r2),
-      Field("posteriorProbability", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.posteriorProb),
-      Field("pval", FloatType,
-        Some(""),
-        resolve = _.value.pval)
-    ))
-
-  val gecko = ObjectType("Gecko",
-    "",
-    fields[Backend, Gecko](
-      Field("genes", ListType(gene),
-        Some(""),
-        resolve = rsl => genesFetcher.deferSeq(rsl.value.geneIds)),
-      Field("tagVariants", ListType(variant),
-        Some(""),
-        resolve = _.value.tagVariants),
-      Field("indexVariants", ListType(variant),
-        Some(""),
-        resolve = _.value.indexVariants),
-      Field("studies", ListType(study),
-        Some(""),
-        resolve = rsl => studiesFetcher.deferSeq(rsl.value.studies)),
-      Field("geneTagVariants", ListType(geneTagVariant),
-        Some(""),
-        resolve = _.value.geneTagVariants),
-      Field("tagVariantIndexVariantStudies", ListType(tagVariantIndexVariantStudy),
-        Some(""),
-        resolve = _.value.tagVariantIndexVariantStudies)
-    ))
-
-  val overlap = ObjectType("Overlap",
-  "This element represent an overlap between two variants for two studies",
-    fields[Backend, OverlappedVariant](
-      Field("variantIdA", StringType, None, resolve = _.value.variantIdA),
-      Field("variantIdB", StringType, None, resolve = _.value.variantIdB),
-      Field("overlapAB", IntType, None, resolve = _.value.overlapAB),
-      Field("distinctA", IntType, None, resolve = _.value.distinctA),
-      Field("distinctB", IntType, None, resolve = _.value.distinctB),
-    ))
-
-  val overlappedStudy = ObjectType("OverlappedStudy",
-    "This element represent a overlap between two stduies",
-    fields[Backend, OverlapRow](
-      Field("study", study,
-        Some("A study object"),
-        resolve = rsl => studiesFetcher.defer(rsl.value.stid)),
-      Field("numOverlapLoci", IntType,
-        Some("Orig variant id which is been used for computing the " +
-          "overlap with the referenced study"),
-        resolve = _.value.numOverlapLoci)
-    ))
-
-  val overlappedVariantsStudies = ObjectType("OverlappedVariantsStudies",
-    "This element represent a overlap between two stduies",
-    fields[Backend, OverlappedVariantsStudy](
-      Field("study", OptionType(study),
-        Some("A study object"),
-        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
-      Field("overlaps", ListType(overlap),
-        Some("Orig variant id which is been used for computing the " +
-          "overlap with the referenced study"),
-        resolve = _.value.overlaps)
-    ))
-
-  val topOverlappedStudies = ObjectType("TopOverlappedStudies",
-    "This element represent a overlap between two stduies",
-    fields[Backend, OverlappedLociStudy](
-      Field("study", OptionType(study),
-        Some("A study object"),
-        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
-      Field("topStudiesByLociOverlap", ListType(overlappedStudy),
-        Some("Top N studies ordered by loci overlap"),
-        resolve = _.value.topOverlappedStudies)
-    ))
-
-  val studyForGene = ObjectType("StudyForGene", "",
-    fields[Backend, String](
-      Field("study", study,
-        Some("A study object"),
-        resolve = rsl => studiesFetcher.defer(rsl.value))
-    ))
-
-  val overlappedInfoForStudy = ObjectType("OverlappedInfoForStudy", "",
-    fields[Backend, (String, Seq[String])](
-      Field("study", OptionType(study),
-        Some("A study object"),
-        resolve = rsl => studiesFetcher.deferOpt(rsl.value._1)),
-      Field("overlappedVariantsForStudies", ListType(overlappedVariantsStudies),
-        Some(""),
-        resolve = rsl => rsl.ctx.getOverlapVariantsForStudies(rsl.value._1, rsl.value._2)),
-      Field("variantIntersectionSet", ListType(StringType),
-        Some(""),
-        resolve = rsl => rsl.ctx.getOverlapVariantsIntersectionForStudies(rsl.value._1, rsl.value._2))
-    ))
-
-  val manhattan = ObjectType("Manhattan",
-    "This element represents a Manhattan like plot",
-    fields[Backend, ManhattanTable](
-      Field("associations", ListType(manhattanAssociation),
-        Some("A list of associations"),
-        resolve = _.value.associations),
-      Field("topOverlappedStudies", OptionType(topOverlappedStudies),
-        Some("A list of overlapped studies"),
-        arguments = pageIndex :: pageSize :: Nil,
-        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.value.studyId, ctx.arg(pageIndex), ctx.arg(pageSize)))
-    ))
-
-  val pheWAS = ObjectType("PheWAS",
-    "This element represents a PheWAS like plot",
-    fields[Backend, PheWASTable](
-      Field("associations", ListType(pheWASAssociation),
-        Some("A list of associations"),
-        resolve = _.value.associations)
-    ))
+//  val manhattanAssociation = ObjectType("ManhattanAssociation",
+//  "This element represents an association between a trait and a variant through a study",
+//    fields[Backend, ManhattanAssociation](
+//      Field("variant", variant,
+//        Some("Index variant"),
+//        resolve = r => variantsFetcher.defer(r.value.variantId)),
+//      Field("pval", FloatType,
+//        Some("Computed p-Value"),
+//        resolve = _.value.pval),
+//      Field("bestGenes", ListType(scoredGene),
+//        Some("A list of best genes associated"),
+//        resolve = _.value.bestGenes),
+//      Field("credibleSetSize", OptionType(LongType),
+//      Some("The cardinal of the set defined as tag variants for an index variant coming from crediblesets"),
+//        resolve = _.value.crediblbeSetSize),
+//      Field("ldSetSize", OptionType(LongType),
+//        Some("The cardinal of the set defined as tag variants for an index variant coming from ld expansion"),
+//        resolve = _.value.ldSetSize),
+//      Field("totalSetSize", LongType,
+//        Some("The cardinal of the set defined as tag variants for an index variant coming from any expansion"),
+//        resolve = _.value.totalSetSize)
+//    ))
 
 
-  val tagVariantsAndStudiesForIndexVariant = ObjectType("TagVariantsAndStudiesForIndexVariant",
-    "A list of rows with each link",
-    fields[Backend, IndexVariantTable](
-      Field("associations", ListType(indexVariantAssociation),
-        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
-        resolve = _.value.associations)
-    ))
+//  val pheWASAssociation = ObjectType("PheWASAssociation",
+//    "This element represents an association between a variant and a reported trait through a study",
+//    fields[Backend, VariantPheWAS](
+//      Field("study", OptionType(study),
+//        Some("Study Object"),
+//        resolve = rsl => studiesFetcher.deferOpt(rsl.value.stid)),
+//      Field("pval", FloatType,
+//        Some("Computed p-Value"),
+//        resolve = _.value.pval),
+//      Field("beta", FloatType,
+//        Some("beta"),
+//        resolve = _.value.beta),
+//      Field("nTotal", OptionType(LongType),
+//        Some("total sample size (variant level)"),
+//        resolve = _.value.nSamplesVariant),
+//      Field("nCases", OptionType(LongType),
+//        Some("number of cases (variant level)"),
+//        resolve = _.value.nCasesVariant),
+//      Field("nTotalStudy", OptionType(LongType),
+//        Some("total sample size (study level, available when variant level is not provided)"),
+//        resolve = _.value.nSamplesStudy),
+//      Field("nCasesStudy", OptionType(LongType),
+//        Some("number of cases (study level, available when variant level is not provided)"),
+//        resolve = _.value.nCasesStudy),
+//      Field("oddsRatio", OptionType(FloatType),
+//        Some("Odds ratio (if case control)"),
+//        resolve = _.value.oddRatio),
+//      Field("chip", StringType,
+//        Some("Chip type: 'metabochip' 'inmunochip', 'genome wide'"),
+//        resolve = _.value.chip),
+//      Field("info", OptionType(FloatType),
+//        Some("Info"),
+//        resolve = _.value.info)
+//    ))
 
-  val indexVariantsAndStudiesForTagVariant = ObjectType("IndexVariantsAndStudiesForTagVariant",
-    "A list of rows with each link",
-    fields[Backend, TagVariantTable](
-      Field("associations", ListType(tagVariantAssociation),
-        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
-        resolve = _.value.associations)
-    ))
+//  val geneTagVariant = ObjectType("GeneTagVariant",
+//    "",
+//    fields[Backend, GeneTagVariant](
+//      Field("geneId", StringType,
+//        Some(""),
+//        resolve = _.value.geneId),
+//      Field("tagVariantId", StringType,
+//        Some(""),
+//        resolve = _.value.tagVariantId),
+//      Field("overallScore", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.overallScore)
+//    ))
+
+//  val tagVariantIndexVariantStudy = ObjectType("TagVariantIndexVariantStudy",
+//    "",
+//    fields[Backend, TagVariantIndexVariantStudy](
+//      Field("tagVariantId", StringType,
+//        Some(""),
+//        resolve = _.value.tagVariantId),
+//      Field("indexVariantId", StringType,
+//        Some(""),
+//        resolve = _.value.indexVariantId),
+//      Field("studyId", StringType,
+//        Some(""),
+//        resolve = _.value.studyId),
+//      Field("r2", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.r2),
+//      Field("posteriorProbability", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.posteriorProb),
+//      Field("pval", FloatType,
+//        Some(""),
+//        resolve = _.value.pval)
+//    ))
+
+//  val gecko = ObjectType("Gecko",
+//    "",
+//    fields[Backend, Gecko](
+//      Field("genes", ListType(gene),
+//        Some(""),
+//        resolve = rsl => genesFetcher.deferSeq(rsl.value.geneIds)),
+//      Field("tagVariants", ListType(variant),
+//        Some(""),
+//        resolve = _.value.tagVariants),
+//      Field("indexVariants", ListType(variant),
+//        Some(""),
+//        resolve = _.value.indexVariants),
+//      Field("studies", ListType(study),
+//        Some(""),
+//        resolve = rsl => studiesFetcher.deferSeq(rsl.value.studies)),
+//      Field("geneTagVariants", ListType(geneTagVariant),
+//        Some(""),
+//        resolve = _.value.geneTagVariants),
+//      Field("tagVariantIndexVariantStudies", ListType(tagVariantIndexVariantStudy),
+//        Some(""),
+//        resolve = _.value.tagVariantIndexVariantStudies)
+//    ))
+
+//  val overlap = ObjectType("Overlap",
+//  "This element represent an overlap between two variants for two studies",
+//    fields[Backend, OverlappedVariant](
+//      Field("variantIdA", StringType, None, resolve = _.value.variantIdA),
+//      Field("variantIdB", StringType, None, resolve = _.value.variantIdB),
+//      Field("overlapAB", IntType, None, resolve = _.value.overlapAB),
+//      Field("distinctA", IntType, None, resolve = _.value.distinctA),
+//      Field("distinctB", IntType, None, resolve = _.value.distinctB),
+//    ))
+
+//  val overlappedStudy = ObjectType("OverlappedStudy",
+//    "This element represent a overlap between two stduies",
+//    fields[Backend, OverlapRow](
+//      Field("study", study,
+//        Some("A study object"),
+//        resolve = rsl => studiesFetcher.defer(rsl.value.stid)),
+//      Field("numOverlapLoci", IntType,
+//        Some("Orig variant id which is been used for computing the " +
+//          "overlap with the referenced study"),
+//        resolve = _.value.numOverlapLoci)
+//    ))
+
+//  val overlappedVariantsStudies = ObjectType("OverlappedVariantsStudies",
+//    "This element represent a overlap between two stduies",
+//    fields[Backend, OverlappedVariantsStudy](
+//      Field("study", OptionType(study),
+//        Some("A study object"),
+//        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
+//      Field("overlaps", ListType(overlap),
+//        Some("Orig variant id which is been used for computing the " +
+//          "overlap with the referenced study"),
+//        resolve = _.value.overlaps)
+//    ))
+
+//  val topOverlappedStudies = ObjectType("TopOverlappedStudies",
+//    "This element represent a overlap between two stduies",
+//    fields[Backend, OverlappedLociStudy](
+//      Field("study", OptionType(study),
+//        Some("A study object"),
+//        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
+//      Field("topStudiesByLociOverlap", ListType(overlappedStudy),
+//        Some("Top N studies ordered by loci overlap"),
+//        resolve = _.value.topOverlappedStudies)
+//    ))
+
+//  val studyForGene = ObjectType("StudyForGene", "",
+//    fields[Backend, String](
+//      Field("study", study,
+//        Some("A study object"),
+//        resolve = rsl => studiesFetcher.defer(rsl.value))
+//    ))
+
+//  val overlappedInfoForStudy = ObjectType("OverlappedInfoForStudy", "",
+//    fields[Backend, (String, Seq[String])](
+//      Field("study", OptionType(study),
+//        Some("A study object"),
+//        resolve = rsl => studiesFetcher.deferOpt(rsl.value._1)),
+//      Field("overlappedVariantsForStudies", ListType(overlappedVariantsStudies),
+//        Some(""),
+//        resolve = rsl => rsl.ctx.getOverlapVariantsForStudies(rsl.value._1, rsl.value._2)),
+//      Field("variantIntersectionSet", ListType(StringType),
+//        Some(""),
+//        resolve = rsl => rsl.ctx.getOverlapVariantsIntersectionForStudies(rsl.value._1, rsl.value._2))
+//    ))
+
+//  val manhattan = ObjectType("Manhattan",
+//    "This element represents a Manhattan like plot",
+//    fields[Backend, ManhattanTable](
+//      Field("associations", ListType(manhattanAssociation),
+//        Some("A list of associations"),
+//        resolve = _.value.associations),
+//      Field("topOverlappedStudies", OptionType(topOverlappedStudies),
+//        Some("A list of overlapped studies"),
+//        arguments = pageIndex :: pageSize :: Nil,
+//        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.value.studyId, ctx.arg(pageIndex), ctx.arg(pageSize)))
+//    ))
+
+//  val pheWAS = ObjectType("PheWAS",
+//    "This element represents a PheWAS like plot",
+//    fields[Backend, PheWASTable](
+//      Field("associations", ListType(pheWASAssociation),
+//        Some("A list of associations"),
+//        resolve = _.value.associations)
+//    ))
+
+
+//  val tagVariantsAndStudiesForIndexVariant = ObjectType("TagVariantsAndStudiesForIndexVariant",
+//    "A list of rows with each link",
+//    fields[Backend, IndexVariantTable](
+//      Field("associations", ListType(indexVariantAssociation),
+//        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
+//        resolve = _.value.associations)
+//    ))
+
+//  val indexVariantsAndStudiesForTagVariant = ObjectType("IndexVariantsAndStudiesForTagVariant",
+//    "A list of rows with each link",
+//    fields[Backend, TagVariantTable](
+//      Field("associations", ListType(tagVariantAssociation),
+//        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
+//        resolve = _.value.associations)
+//    ))
 
   val tissue = ObjectType("Tissue",
     "",
@@ -640,81 +645,81 @@ object GQLSchema {
         resolve = _.value.fpreds)
     ))
 
-  val variantSearchResult = ObjectType("VariantSearchResult",
-    "Variant search result object",
-    fields[Backend, VariantSearchResult](
-      Field("variant", variant,
-        Some("A variant"),
-        resolve = _.value.variant)
-    ))
+//  val variantSearchResult = ObjectType("VariantSearchResult",
+//    "Variant search result object",
+//    fields[Backend, VariantSearchResult](
+//      Field("variant", variant,
+//        Some("A variant"),
+//        resolve = _.value.variant)
+//    ))
 
-  val searchResult = ObjectType("SearchResult",
-    "Search data by a query string",
-    fields[Backend, SearchResultSet](
-      Field("totalGenes", LongType,
-        Some("Total number of genes found"),
-        resolve = _.value.totalGenes),
-      Field("totalVariants", LongType,
-        Some("Total number of variants found"),
-        resolve = _.value.totalVariants),
-      Field("totalStudies", LongType,
-        Some("Total number of studies found"),
-        resolve = _.value.totalStudies),
-      Field("genes", ListType(gene),
-        Some("Gene search result list"),
-        resolve = _.value.genes),
-      Field("variants", ListType(variantSearchResult),
-        Some("Variant search result list"),
-        resolve = _.value.variants),
-      Field("studies", ListType(study),
-        Some("Study search result list"),
-        resolve = _.value.studies)
-    ))
+//  val searchResult = ObjectType("SearchResult",
+//    "Search data by a query string",
+//    fields[Backend, SearchResultSet](
+//      Field("totalGenes", LongType,
+//        Some("Total number of genes found"),
+//        resolve = _.value.totalGenes),
+//      Field("totalVariants", LongType,
+//        Some("Total number of variants found"),
+//        resolve = _.value.totalVariants),
+//      Field("totalStudies", LongType,
+//        Some("Total number of studies found"),
+//        resolve = _.value.totalStudies),
+//      Field("genes", ListType(gene),
+//        Some("Gene search result list"),
+//        resolve = _.value.genes),
+//      Field("variants", ListType(variantSearchResult),
+//        Some("Variant search result list"),
+//        resolve = _.value.variants),
+//      Field("studies", ListType(study),
+//        Some("Study search result list"),
+//        resolve = _.value.studies)
+//    ))
 
   val query = ObjectType(
     "Query", fields[Backend, Unit](
-      Field("search", searchResult,
-        arguments = queryString :: pageIndex :: pageSize :: Nil,
-        resolve = ctx =>
-          ctx.ctx.getSearchResultSet(ctx.arg(queryString), ctx.arg(pageIndex), ctx.arg(pageSize))),
+//      Field("search", searchResult,
+//        arguments = queryString :: pageIndex :: pageSize :: Nil,
+//        resolve = ctx =>
+//          ctx.ctx.getSearchResultSet(ctx.arg(queryString), ctx.arg(pageIndex), ctx.arg(pageSize))),
       Field("studyInfo", OptionType(study),
         arguments = studyId :: Nil,
         resolve = ctx => studiesFetcher.deferOpt(ctx.arg(studyId))),
       Field("variantInfo", OptionType(variant),
         arguments = variantId :: Nil,
         resolve = ctx => variantsFetcher.deferOpt(ctx.arg(variantId))),
-      Field("studiesForGene", ListType(studyForGene),
-        arguments = geneId :: Nil,
-        resolve = ctx => ctx.ctx.getStudiesForGene(ctx.arg(geneId))),
-      Field("manhattan", manhattan,
-        arguments = studyId :: pageIndex :: pageSize :: Nil,
-        resolve = ctx => ctx.ctx.buildManhattanTable(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-      Field("topOverlappedStudies", topOverlappedStudies,
-        arguments = studyId :: pageIndex :: pageSize :: Nil,
-        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-      Field("overlapInfoForStudy", overlappedInfoForStudy,
-        arguments = studyId :: studyIds :: Nil,
-        resolve = ctx => (ctx.arg(studyId),  ctx.arg(studyIds))),
-      Field("tagVariantsAndStudiesForIndexVariant", tagVariantsAndStudiesForIndexVariant,
-        arguments = variantId :: pageIndex :: pageSize :: Nil,
-        resolve = ctx =>
-          ctx.ctx.buildIndexVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-      Field("indexVariantsAndStudiesForTagVariant", indexVariantsAndStudiesForTagVariant,
-        arguments = variantId :: pageIndex :: pageSize :: Nil,
-        resolve = ctx =>
-          ctx.ctx.buildTagVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-      Field("pheWAS", pheWAS,
-        arguments = variantId :: pageIndex :: pageSize :: Nil,
-        resolve = ctx => ctx.ctx.buildPheWASTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-      Field("gecko", OptionType(gecko),
-        arguments = chromosome :: dnaPosStart :: dnaPosEnd :: Nil,
-        resolve = ctx => ctx.ctx.buildGecko(ctx.arg(chromosome), ctx.arg(dnaPosStart), ctx.arg(dnaPosEnd))),
-      Field("genesForVariantSchema", v2gSchema,
-        arguments = Nil,
-        resolve = ctx => ctx.ctx.getG2VSchema),
-      Field("genesForVariant", ListType(geneForVariant),
-        arguments = variantId :: Nil,
-        resolve = ctx => ctx.ctx.buildG2VByVariant(ctx.arg(variantId))),
+//      Field("studiesForGene", ListType(studyForGene),
+//        arguments = geneId :: Nil,
+//        resolve = ctx => ctx.ctx.getStudiesForGene(ctx.arg(geneId))),
+//      Field("manhattan", manhattan,
+//        arguments = studyId :: pageIndex :: pageSize :: Nil,
+//        resolve = ctx => ctx.ctx.buildManhattanTable(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+//      Field("topOverlappedStudies", topOverlappedStudies,
+//        arguments = studyId :: pageIndex :: pageSize :: Nil,
+//        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+//      Field("overlapInfoForStudy", overlappedInfoForStudy,
+//        arguments = studyId :: studyIds :: Nil,
+//        resolve = ctx => (ctx.arg(studyId),  ctx.arg(studyIds))),
+//      Field("tagVariantsAndStudiesForIndexVariant", tagVariantsAndStudiesForIndexVariant,
+//        arguments = variantId :: pageIndex :: pageSize :: Nil,
+//        resolve = ctx =>
+//          ctx.ctx.buildIndexVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+//      Field("indexVariantsAndStudiesForTagVariant", indexVariantsAndStudiesForTagVariant,
+//        arguments = variantId :: pageIndex :: pageSize :: Nil,
+//        resolve = ctx =>
+//          ctx.ctx.buildTagVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+//      Field("pheWAS", pheWAS,
+//        arguments = variantId :: pageIndex :: pageSize :: Nil,
+//        resolve = ctx => ctx.ctx.buildPheWASTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+//      Field("gecko", OptionType(gecko),
+//        arguments = chromosome :: dnaPosStart :: dnaPosEnd :: Nil,
+//        resolve = ctx => ctx.ctx.buildGecko(ctx.arg(chromosome), ctx.arg(dnaPosStart), ctx.arg(dnaPosEnd))),
+//      Field("genesForVariantSchema", v2gSchema,
+//        arguments = Nil,
+//        resolve = ctx => ctx.ctx.getG2VSchema),
+//      Field("genesForVariant", ListType(geneForVariant),
+//        arguments = variantId :: Nil,
+//        resolve = ctx => ctx.ctx.buildG2VByVariant(ctx.arg(variantId))),
 //      Field("variantsForGene", ListType(geneForVariant),
 //        arguments = geneId :: Nil,
 //        resolve = ctx => ctx.ctx.buildG2VByGene(ctx.arg(geneId)))

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -220,50 +220,50 @@ object GQLSchema {
 //        resolve = _.value.posteriorProbability)
 //    ))
 
-//  val tagVariantAssociation = ObjectType("TagVariantAssociation",
-//    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
-//      "via an expansion method (either ldExpansion or FineMapping)",
-//    fields[Backend, TagVariantAssociation](
-//      Field("indexVariant", variant,
-//        Some("Tag variant ID as ex. 1_12345_A_T"),
-//        resolve = _.value.indexVariant),
-//      Field("study", study,
-//        Some("study ID"),
-//        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
-//      Field("pval", FloatType,
-//        Some("p-val between a study and an the provided index variant"),
-//        resolve = _.value.pval),
-//      Field("nTotal", IntType,
-//        Some("n total cases (n initial + n replication)"),
-//        resolve = _.value.nTotal),
-//      Field("nCases", IntType,
-//        Some("n cases"),
-//        resolve = _.value.nCases),
-//      Field("overallR2", OptionType(FloatType),
-//        Some("study ID"),
-//        resolve = _.value.r2),
-//      Field("afr1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.afr1000GProp),
-//      Field("amr1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.amr1000GProp),
-//      Field("eas1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.eas1000GProp),
-//      Field("eur1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.eur1000GProp),
-//      Field("sas1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.sas1000GProp),
-//      Field("log10Abf", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.log10Abf),
-//      Field("posteriorProbability", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.posteriorProbability)
-//    ))
+  val tagVariantAssociation = ObjectType("TagVariantAssociation",
+    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
+      "via an expansion method (either ldExpansion or FineMapping)",
+    fields[Backend, TagVariantAssociation](
+      Field("indexVariant", variant,
+        Some("Tag variant ID as ex. 1_12345_A_T"),
+        resolve = _.value.indexVariant),
+      Field("study", study,
+        Some("study ID"),
+        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
+      Field("pval", FloatType,
+        Some("p-val between a study and an the provided index variant"),
+        resolve = _.value.pval),
+      Field("nTotal", IntType,
+        Some("n total cases (n initial + n replication)"),
+        resolve = _.value.nTotal),
+      Field("nCases", IntType,
+        Some("n cases"),
+        resolve = _.value.nCases),
+      Field("overallR2", OptionType(FloatType),
+        Some("study ID"),
+        resolve = _.value.r2),
+      Field("afr1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.afr1000GProp),
+      Field("amr1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.amr1000GProp),
+      Field("eas1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.eas1000GProp),
+      Field("eur1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.eur1000GProp),
+      Field("sas1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.sas1000GProp),
+      Field("log10Abf", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.log10Abf),
+      Field("posteriorProbability", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.posteriorProbability)
+    ))
 
 //  val manhattanAssociation = ObjectType("ManhattanAssociation",
 //  "This element represents an association between a trait and a variant through a study",
@@ -478,172 +478,172 @@ object GQLSchema {
 //        resolve = _.value.associations)
 //    ))
 
-//  val indexVariantsAndStudiesForTagVariant = ObjectType("IndexVariantsAndStudiesForTagVariant",
+  val indexVariantsAndStudiesForTagVariant = ObjectType("IndexVariantsAndStudiesForTagVariant",
+    "A list of rows with each link",
+    fields[Backend, TagVariantTable](
+      Field("associations", ListType(tagVariantAssociation),
+        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
+        resolve = _.value.associations)
+    ))
+
+//  val tissue = ObjectType("Tissue",
+//    "",
+//    fields[Backend, Tissue](
+//      Field("id", StringType,
+//        Some(""),
+//        resolve = _.value.id),
+//      Field("name", OptionType(StringType),
+//        Some(""),
+//        resolve = _.value.name)
+//    ))
+//
+//  val g2vSchemaElement = ObjectType("G2VSchemaElement",
 //    "A list of rows with each link",
-//    fields[Backend, TagVariantTable](
-//      Field("associations", ListType(tagVariantAssociation),
-//        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
-//        resolve = _.value.associations)
+//    fields[Backend, G2VSchemaElement](
+//      Field("id", StringType,
+//        Some(""),
+//        resolve = _.value.id),
+//      Field("sourceId", StringType,
+//        Some(""),
+//        resolve = _.value.sourceId),
+//      Field("tissues", ListType(tissue),
+//        Some(""),
+//        resolve = _.value.tissues)
+//    ))
+//
+//  val v2gSchema = ObjectType("G2VSchema",
+//    "A list of rows with each link",
+//    fields[Backend, G2VSchema](
+//      Field("qtls", ListType(g2vSchemaElement),
+//        Some("qtl structure definition"),
+//        resolve = _.value.qtls),
+//      Field("intervals", ListType(g2vSchemaElement),
+//        Some("qtl structure definition"),
+//        resolve = _.value.intervals),
+//      Field("functionalPredictions", ListType(g2vSchemaElement),
+//        Some("qtl structure definition"),
+//        resolve = _.value.functionalPredictions)
+//    ))
+//
+//  val qtlTissue = ObjectType("QTLTissue",
+//    "",
+//    fields[Backend, QTLTissue](
+//      Field("tissue", tissue,
+//        Some(""),
+//        resolve = _.value.tissue),
+//      Field("quantile", FloatType,
+//        Some(""),
+//        resolve = _.value.quantile),
+//      Field("beta", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.beta),
+//      Field("pval", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.pval)
+//    ))
+//
+//  val intervalTissue = ObjectType("IntervalTissue",
+//    "",
+//    fields[Backend, IntervalTissue](
+//      Field("tissue", tissue,
+//        Some(""),
+//        resolve = _.value.tissue),
+//      Field("quantile", FloatType,
+//        Some(""),
+//        resolve = _.value.quantile),
+//      Field("score", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.score)
+//    ))
+//
+//  val fpredTissue = ObjectType("FPredTissue",
+//    "",
+//    fields[Backend, FPredTissue](
+//      Field("tissue", tissue,
+//        Some(""),
+//        resolve = _.value.tissue),
+//      Field("maxEffectLabel", OptionType(StringType),
+//        Some(""),
+//        resolve = _.value.maxEffectLabel),
+//      Field("maxEffectScore", OptionType(FloatType),
+//        Some(""),
+//        resolve = _.value.maxEffectScore)
 //    ))
 
-  val tissue = ObjectType("Tissue",
-    "",
-    fields[Backend, Tissue](
-      Field("id", StringType,
-        Some(""),
-        resolve = _.value.id),
-      Field("name", OptionType(StringType),
-        Some(""),
-        resolve = _.value.name)
-    ))
 
-  val g2vSchemaElement = ObjectType("G2VSchemaElement",
-    "A list of rows with each link",
-    fields[Backend, G2VSchemaElement](
-      Field("id", StringType,
-        Some(""),
-        resolve = _.value.id),
-      Field("sourceId", StringType,
-        Some(""),
-        resolve = _.value.sourceId),
-      Field("tissues", ListType(tissue),
-        Some(""),
-        resolve = _.value.tissues)
-    ))
+//  val qtlElement = ObjectType("QTLElement",
+//    "A list of rows with each link",
+//    fields[Backend, G2VElement[QTLTissue]](
+//      Field("typeId", StringType,
+//        Some(""),
+//        resolve = _.value.id),
+//      Field("sourceId", StringType,
+//        Some(""),
+//        resolve = _.value.sourceId),
+//      Field("aggregatedScore", FloatType,
+//        Some(""),
+//        resolve = _.value.aggregatedScore),
+//      Field("tissues", ListType(qtlTissue),
+//        Some(""),
+//        resolve = _.value.tissues)
+//    ))
+//
+//  val intervalElement = ObjectType("IntervalElement",
+//    "A list of rows with each link",
+//    fields[Backend, G2VElement[IntervalTissue]](
+//      Field("typeId", StringType,
+//        Some(""),
+//        resolve = _.value.id),
+//      Field("sourceId", StringType,
+//        Some(""),
+//        resolve = _.value.sourceId),
+//      Field("aggregatedScore", FloatType,
+//        Some(""),
+//        resolve = _.value.aggregatedScore),
+//      Field("tissues", ListType(intervalTissue),
+//        Some(""),
+//        resolve = _.value.tissues)
+//    ))
+//
+//  val fPredElement = ObjectType("FunctionalPredictionElement",
+//    "A list of rows with each link",
+//    fields[Backend, G2VElement[FPredTissue]](
+//      Field("typeId", StringType,
+//        Some(""),
+//        resolve = _.value.id),
+//      Field("sourceId", StringType,
+//        Some(""),
+//        resolve = _.value.sourceId),
+//      Field("aggregatedScore", FloatType,
+//        Some(""),
+//        resolve = _.value.aggregatedScore),
+//      Field("tissues", ListType(fpredTissue),
+//        Some(""),
+//        resolve = _.value.tissues)
+//    ))
 
-  val v2gSchema = ObjectType("G2VSchema",
-    "A list of rows with each link",
-    fields[Backend, G2VSchema](
-      Field("qtls", ListType(g2vSchemaElement),
-        Some("qtl structure definition"),
-        resolve = _.value.qtls),
-      Field("intervals", ListType(g2vSchemaElement),
-        Some("qtl structure definition"),
-        resolve = _.value.intervals),
-      Field("functionalPredictions", ListType(g2vSchemaElement),
-        Some("qtl structure definition"),
-        resolve = _.value.functionalPredictions)
-    ))
-
-  val qtlTissue = ObjectType("QTLTissue",
-    "",
-    fields[Backend, QTLTissue](
-      Field("tissue", tissue,
-        Some(""),
-        resolve = _.value.tissue),
-      Field("quantile", FloatType,
-        Some(""),
-        resolve = _.value.quantile),
-      Field("beta", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.beta),
-      Field("pval", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.pval)
-    ))
-
-  val intervalTissue = ObjectType("IntervalTissue",
-    "",
-    fields[Backend, IntervalTissue](
-      Field("tissue", tissue,
-        Some(""),
-        resolve = _.value.tissue),
-      Field("quantile", FloatType,
-        Some(""),
-        resolve = _.value.quantile),
-      Field("score", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.score)
-    ))
-
-  val fpredTissue = ObjectType("FPredTissue",
-    "",
-    fields[Backend, FPredTissue](
-      Field("tissue", tissue,
-        Some(""),
-        resolve = _.value.tissue),
-      Field("maxEffectLabel", OptionType(StringType),
-        Some(""),
-        resolve = _.value.maxEffectLabel),
-      Field("maxEffectScore", OptionType(FloatType),
-        Some(""),
-        resolve = _.value.maxEffectScore)
-    ))
-
-
-  val qtlElement = ObjectType("QTLElement",
-    "A list of rows with each link",
-    fields[Backend, G2VElement[QTLTissue]](
-      Field("typeId", StringType,
-        Some(""),
-        resolve = _.value.id),
-      Field("sourceId", StringType,
-        Some(""),
-        resolve = _.value.sourceId),
-      Field("aggregatedScore", FloatType,
-        Some(""),
-        resolve = _.value.aggregatedScore),
-      Field("tissues", ListType(qtlTissue),
-        Some(""),
-        resolve = _.value.tissues)
-    ))
-
-  val intervalElement = ObjectType("IntervalElement",
-    "A list of rows with each link",
-    fields[Backend, G2VElement[IntervalTissue]](
-      Field("typeId", StringType,
-        Some(""),
-        resolve = _.value.id),
-      Field("sourceId", StringType,
-        Some(""),
-        resolve = _.value.sourceId),
-      Field("aggregatedScore", FloatType,
-        Some(""),
-        resolve = _.value.aggregatedScore),
-      Field("tissues", ListType(intervalTissue),
-        Some(""),
-        resolve = _.value.tissues)
-    ))
-
-  val fPredElement = ObjectType("FunctionalPredictionElement",
-    "A list of rows with each link",
-    fields[Backend, G2VElement[FPredTissue]](
-      Field("typeId", StringType,
-        Some(""),
-        resolve = _.value.id),
-      Field("sourceId", StringType,
-        Some(""),
-        resolve = _.value.sourceId),
-      Field("aggregatedScore", FloatType,
-        Some(""),
-        resolve = _.value.aggregatedScore),
-      Field("tissues", ListType(fpredTissue),
-        Some(""),
-        resolve = _.value.tissues)
-    ))
-
-  val geneForVariant = ObjectType("GeneForVariant",
-    "A list of rows with each link",
-    fields[Backend, G2VAssociation](
-      Field("gene", gene,
-        Some("Associated scored gene"),
-        resolve = rsl => genesFetcher.defer(rsl.value.geneId)),
-      Field("variant", StringType,
-        Some("Associated scored variant"),
-        resolve = _.value.variantId),
-      Field("overallScore", FloatType,
-        Some(""),
-        resolve = _.value.overallScore),
-      Field("qtls", ListType(qtlElement),
-        Some(""),
-        resolve = _.value.qtls),
-      Field("intervals", ListType(intervalElement),
-        Some(""),
-        resolve = _.value.intervals),
-      Field("functionalPredictions", ListType(fPredElement),
-        Some(""),
-        resolve = _.value.fpreds)
-    ))
+//  val geneForVariant = ObjectType("GeneForVariant",
+//    "A list of rows with each link",
+//    fields[Backend, G2VAssociation](
+//      Field("gene", gene,
+//        Some("Associated scored gene"),
+//        resolve = rsl => genesFetcher.defer(rsl.value.geneId)),
+//      Field("variant", StringType,
+//        Some("Associated scored variant"),
+//        resolve = _.value.variantId),
+//      Field("overallScore", FloatType,
+//        Some(""),
+//        resolve = _.value.overallScore),
+//      Field("qtls", ListType(qtlElement),
+//        Some(""),
+//        resolve = _.value.qtls),
+//      Field("intervals", ListType(intervalElement),
+//        Some(""),
+//        resolve = _.value.intervals),
+//      Field("functionalPredictions", ListType(fPredElement),
+//        Some(""),
+//        resolve = _.value.fpreds)
+//    ))
 
 //  val variantSearchResult = ObjectType("VariantSearchResult",
 //    "Variant search result object",
@@ -704,10 +704,10 @@ object GQLSchema {
 //        arguments = variantId :: pageIndex :: pageSize :: Nil,
 //        resolve = ctx =>
 //          ctx.ctx.buildIndexVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-//      Field("indexVariantsAndStudiesForTagVariant", indexVariantsAndStudiesForTagVariant,
-//        arguments = variantId :: pageIndex :: pageSize :: Nil,
-//        resolve = ctx =>
-//          ctx.ctx.buildTagVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+      Field("indexVariantsAndStudiesForTagVariant", indexVariantsAndStudiesForTagVariant,
+        arguments = variantId :: pageIndex :: pageSize :: Nil,
+        resolve = ctx =>
+          ctx.ctx.buildTagVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
 //      Field("pheWAS", pheWAS,
 //        arguments = variantId :: pageIndex :: pageSize :: Nil,
 //        resolve = ctx => ctx.ctx.buildPheWASTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -51,8 +51,7 @@ object GQLSchema {
       Field("fwdStrand", OptionType(BooleanType),
         Some("Forward strand true or false"),
         resolve = _.value.fwd),
-//      Field("exons", ListType(LongType),
-      Field("exons", OptionType(StringType),
+      Field("exons", ListType(LongType),
         Some("Approved symbol name of a gene"),
         resolve = _.value.exons)
     ))

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -3,6 +3,7 @@ package models
 import sangria.execution.deferred._
 import sangria.schema._
 import Entities._
+import models.DNA.{Gene, Variant}
 
 object GQLSchema {
   val studyId = Argument("studyId", StringType, description = "Study ID which links a top loci with a trait")
@@ -17,15 +18,13 @@ object GQLSchema {
   val dnaPosEnd = Argument("end", LongType, description = "End position in a specified chromosome")
   val queryString = Argument("queryString", StringType, description = "Query text to search for")
 
-  implicit val geneHasId = HasId[FRM.Gene, String](_.id)
-  implicit val variantHasId = HasId[FRM.Variant, String](_.id)
-  implicit val studyHasId = HasId[FRM.Study, String](_.studyId)
-
-
+  implicit val geneHasId = HasId[Gene, String](_.id)
+  implicit val variantHasId = HasId[Variant, String](_.id)
+  implicit val studyHasId = HasId[Study, String](_.studyId)
 
   val gene = ObjectType("Gene",
   "This element represents a simple gene object which contains id and name",
-    fields[Backend, FRM.Gene](
+    fields[Backend, Gene](
       Field("id", StringType,
         Some("Ensembl Gene ID of a gene"),
         resolve = _.value.id),
@@ -77,10 +76,10 @@ object GQLSchema {
         resolve = _.value.rsId),
       Field("chromosome", StringType,
         Some("Ensembl Gene ID of a gene"),
-        resolve = _.value.position.chrId),
+        resolve = _.value.chromosome),
       Field("position", LongType,
         Some("Approved symbol name of a gene"),
-        resolve = _.value.position.position),
+        resolve = _.value.position),
       Field("refAllele", StringType,
         Some("Ref allele"),
         resolve = _.value.refAllele),
@@ -121,7 +120,7 @@ object GQLSchema {
 
   val study = ObjectType("Study",
   "This element contains all study fields",
-    fields[Backend, FRM.Study](
+    fields[Backend, Study](
       Field("studyId", StringType,
         Some("Study Identifier"),
         resolve = _.value.studyId),

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -175,50 +175,50 @@ object GQLSchema {
         resolve = _.value.traitCategory)
     ))
 
-//  val indexVariantAssociation = ObjectType("IndexVariantAssociation",
-//    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
-//      "via an expansion method (either ldExpansion or FineMapping)",
-//    fields[Backend, IndexVariantAssociation](
-//      Field("tagVariant", variant,
-//        Some("Tag variant ID as ex. 1_12345_A_T"),
-//        resolve = _.value.tagVariant),
-//      Field("study", study,
-//        Some("study ID"),
-//        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
-//      Field("pval", FloatType,
-//        Some("p-val between a study and an the provided index variant"),
-//        resolve = _.value.pval),
-//      Field("nTotal", IntType,
-//        Some("n total cases (n initial + n replication)"),
-//        resolve = _.value.nTotal),
-//      Field("nCases", IntType,
-//        Some("n cases"),
-//        resolve = _.value.nCases),
-//      Field("overallR2", OptionType(FloatType),
-//        Some("study ID"),
-//        resolve = _.value.r2),
-//      Field("afr1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.afr1000GProp),
-//      Field("amr1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.amr1000GProp),
-//      Field("eas1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.eas1000GProp),
-//      Field("eur1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.eur1000GProp),
-//      Field("sas1000GProp", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.sas1000GProp),
-//      Field("log10Abf", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.log10Abf),
-//      Field("posteriorProbability", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.posteriorProbability)
-//    ))
+  val indexVariantAssociation = ObjectType("IndexVariantAssociation",
+    "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
+      "via an expansion method (either ldExpansion or FineMapping)",
+    fields[Backend, IndexVariantAssociation](
+      Field("tagVariant", variant,
+        Some("Tag variant ID as ex. 1_12345_A_T"),
+        resolve = _.value.tagVariant),
+      Field("study", study,
+        Some("study ID"),
+        resolve = rsl => studiesFetcher.defer(rsl.value.studyId)),
+      Field("pval", FloatType,
+        Some("p-val between a study and an the provided index variant"),
+        resolve = _.value.pval),
+      Field("nTotal", IntType,
+        Some("n total cases (n initial + n replication)"),
+        resolve = _.value.nTotal),
+      Field("nCases", IntType,
+        Some("n cases"),
+        resolve = _.value.nCases),
+      Field("overallR2", OptionType(FloatType),
+        Some("study ID"),
+        resolve = _.value.r2),
+      Field("afr1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.afr1000GProp),
+      Field("amr1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.amr1000GProp),
+      Field("eas1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.eas1000GProp),
+      Field("eur1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.eur1000GProp),
+      Field("sas1000GProp", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.sas1000GProp),
+      Field("log10Abf", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.log10Abf),
+      Field("posteriorProbability", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.posteriorProbability)
+    ))
 
   val tagVariantAssociation = ObjectType("TagVariantAssociation",
     "This object represent a link between a triple (study, trait, index_variant) and a tag variant " +
@@ -470,13 +470,13 @@ object GQLSchema {
 //    ))
 
 
-//  val tagVariantsAndStudiesForIndexVariant = ObjectType("TagVariantsAndStudiesForIndexVariant",
-//    "A list of rows with each link",
-//    fields[Backend, IndexVariantTable](
-//      Field("associations", ListType(indexVariantAssociation),
-//        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
-//        resolve = _.value.associations)
-//    ))
+  val tagVariantsAndStudiesForIndexVariant = ObjectType("TagVariantsAndStudiesForIndexVariant",
+    "A list of rows with each link",
+    fields[Backend, IndexVariantTable](
+      Field("associations", ListType(indexVariantAssociation),
+        Some("A list of associations connected to a Index variant and a Study through some expansion methods"),
+        resolve = _.value.associations)
+    ))
 
   val indexVariantsAndStudiesForTagVariant = ObjectType("IndexVariantsAndStudiesForTagVariant",
     "A list of rows with each link",
@@ -700,10 +700,10 @@ object GQLSchema {
 //      Field("overlapInfoForStudy", overlappedInfoForStudy,
 //        arguments = studyId :: studyIds :: Nil,
 //        resolve = ctx => (ctx.arg(studyId),  ctx.arg(studyIds))),
-//      Field("tagVariantsAndStudiesForIndexVariant", tagVariantsAndStudiesForIndexVariant,
-//        arguments = variantId :: pageIndex :: pageSize :: Nil,
-//        resolve = ctx =>
-//          ctx.ctx.buildIndexVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+      Field("tagVariantsAndStudiesForIndexVariant", tagVariantsAndStudiesForIndexVariant,
+        arguments = variantId :: pageIndex :: pageSize :: Nil,
+        resolve = ctx =>
+          ctx.ctx.buildIndexVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
       Field("indexVariantsAndStudiesForTagVariant", indexVariantsAndStudiesForTagVariant,
         arguments = variantId :: pageIndex :: pageSize :: Nil,
         resolve = ctx =>

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -265,210 +265,209 @@ object GQLSchema {
         resolve = _.value.posteriorProbability)
     ))
 
-//  val manhattanAssociation = ObjectType("ManhattanAssociation",
-//  "This element represents an association between a trait and a variant through a study",
-//    fields[Backend, ManhattanAssociation](
-//      Field("variant", variant,
-//        Some("Index variant"),
-//        resolve = r => variantsFetcher.defer(r.value.variantId)),
-//      Field("pval", FloatType,
-//        Some("Computed p-Value"),
-//        resolve = _.value.pval),
-//      Field("bestGenes", ListType(scoredGene),
-//        Some("A list of best genes associated"),
-//        resolve = _.value.bestGenes),
-//      Field("credibleSetSize", OptionType(LongType),
-//      Some("The cardinal of the set defined as tag variants for an index variant coming from crediblesets"),
-//        resolve = _.value.crediblbeSetSize),
-//      Field("ldSetSize", OptionType(LongType),
-//        Some("The cardinal of the set defined as tag variants for an index variant coming from ld expansion"),
-//        resolve = _.value.ldSetSize),
-//      Field("totalSetSize", LongType,
-//        Some("The cardinal of the set defined as tag variants for an index variant coming from any expansion"),
-//        resolve = _.value.totalSetSize)
-//    ))
+  val manhattanAssociation = ObjectType("ManhattanAssociation",
+  "This element represents an association between a trait and a variant through a study",
+    fields[Backend, ManhattanAssociation](
+      Field("variant", variant,
+        Some("Index variant"),
+        resolve = r => variantsFetcher.defer(r.value.variantId)),
+      Field("pval", FloatType,
+        Some("Computed p-Value"),
+        resolve = _.value.pval),
+      Field("bestGenes", ListType(scoredGene),
+        Some("A list of best genes associated"),
+        resolve = _.value.bestGenes),
+      Field("credibleSetSize", OptionType(LongType),
+      Some("The cardinal of the set defined as tag variants for an index variant coming from crediblesets"),
+        resolve = _.value.crediblbeSetSize),
+      Field("ldSetSize", OptionType(LongType),
+        Some("The cardinal of the set defined as tag variants for an index variant coming from ld expansion"),
+        resolve = _.value.ldSetSize),
+      Field("totalSetSize", LongType,
+        Some("The cardinal of the set defined as tag variants for an index variant coming from any expansion"),
+        resolve = _.value.totalSetSize)
+    ))
 
 
-//  val pheWASAssociation = ObjectType("PheWASAssociation",
-//    "This element represents an association between a variant and a reported trait through a study",
-//    fields[Backend, VariantPheWAS](
-//      Field("study", OptionType(study),
-//        Some("Study Object"),
-//        resolve = rsl => studiesFetcher.deferOpt(rsl.value.stid)),
-//      Field("pval", FloatType,
-//        Some("Computed p-Value"),
-//        resolve = _.value.pval),
-//      Field("beta", FloatType,
-//        Some("beta"),
-//        resolve = _.value.beta),
-//      Field("nTotal", OptionType(LongType),
-//        Some("total sample size (variant level)"),
-//        resolve = _.value.nSamplesVariant),
-//      Field("nCases", OptionType(LongType),
-//        Some("number of cases (variant level)"),
-//        resolve = _.value.nCasesVariant),
-//      Field("nTotalStudy", OptionType(LongType),
-//        Some("total sample size (study level, available when variant level is not provided)"),
-//        resolve = _.value.nSamplesStudy),
-//      Field("nCasesStudy", OptionType(LongType),
-//        Some("number of cases (study level, available when variant level is not provided)"),
-//        resolve = _.value.nCasesStudy),
-//      Field("oddsRatio", OptionType(FloatType),
-//        Some("Odds ratio (if case control)"),
-//        resolve = _.value.oddRatio),
-//      Field("chip", StringType,
-//        Some("Chip type: 'metabochip' 'inmunochip', 'genome wide'"),
-//        resolve = _.value.chip),
-//      Field("info", OptionType(FloatType),
-//        Some("Info"),
-//        resolve = _.value.info)
-//    ))
+  val pheWASAssociation = ObjectType("PheWASAssociation",
+    "This element represents an association between a variant and a reported trait through a study",
+    fields[Backend, VariantPheWAS](
+      Field("study", OptionType(study),
+        Some("Study Object"),
+        resolve = rsl => studiesFetcher.deferOpt(rsl.value.stid)),
+      Field("pval", FloatType,
+        Some("Computed p-Value"),
+        resolve = _.value.pval),
+      Field("beta", FloatType,
+        Some("beta"),
+        resolve = _.value.beta),
+      Field("nTotal", OptionType(LongType),
+        Some("total sample size (variant level)"),
+        resolve = _.value.nSamplesVariant),
+      Field("nCases", OptionType(LongType),
+        Some("number of cases (variant level)"),
+        resolve = _.value.nCasesVariant),
+      Field("nTotalStudy", OptionType(LongType),
+        Some("total sample size (study level, available when variant level is not provided)"),
+        resolve = _.value.nSamplesStudy),
+      Field("nCasesStudy", OptionType(LongType),
+        Some("number of cases (study level, available when variant level is not provided)"),
+        resolve = _.value.nCasesStudy),
+      Field("oddsRatio", OptionType(FloatType),
+        Some("Odds ratio (if case control)"),
+        resolve = _.value.oddRatio),
+      Field("chip", StringType,
+        Some("Chip type: 'metabochip' 'inmunochip', 'genome wide'"),
+        resolve = _.value.chip),
+      Field("info", OptionType(FloatType),
+        Some("Info"),
+        resolve = _.value.info)
+    ))
 
-//  val geneTagVariant = ObjectType("GeneTagVariant",
-//    "",
-//    fields[Backend, GeneTagVariant](
-//      Field("geneId", StringType,
-//        Some(""),
-//        resolve = _.value.geneId),
-//      Field("tagVariantId", StringType,
-//        Some(""),
-//        resolve = _.value.tagVariantId),
-//      Field("overallScore", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.overallScore)
-//    ))
+  val geneTagVariant = ObjectType("GeneTagVariant",
+    "",
+    fields[Backend, GeneTagVariant](
+      Field("geneId", StringType,
+        Some(""),
+        resolve = _.value.geneId),
+      Field("tagVariantId", StringType,
+        Some(""),
+        resolve = _.value.tagVariantId),
+      Field("overallScore", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.overallScore)
+    ))
 
-//  val tagVariantIndexVariantStudy = ObjectType("TagVariantIndexVariantStudy",
-//    "",
-//    fields[Backend, TagVariantIndexVariantStudy](
-//      Field("tagVariantId", StringType,
-//        Some(""),
-//        resolve = _.value.tagVariantId),
-//      Field("indexVariantId", StringType,
-//        Some(""),
-//        resolve = _.value.indexVariantId),
-//      Field("studyId", StringType,
-//        Some(""),
-//        resolve = _.value.studyId),
-//      Field("r2", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.r2),
-//      Field("posteriorProbability", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.posteriorProb),
-//      Field("pval", FloatType,
-//        Some(""),
-//        resolve = _.value.pval)
-//    ))
+  val tagVariantIndexVariantStudy = ObjectType("TagVariantIndexVariantStudy",
+    "",
+    fields[Backend, TagVariantIndexVariantStudy](
+      Field("tagVariantId", StringType,
+        Some(""),
+        resolve = _.value.tagVariantId),
+      Field("indexVariantId", StringType,
+        Some(""),
+        resolve = _.value.indexVariantId),
+      Field("studyId", StringType,
+        Some(""),
+        resolve = _.value.studyId),
+      Field("r2", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.r2),
+      Field("posteriorProbability", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.posteriorProb),
+      Field("pval", FloatType,
+        Some(""),
+        resolve = _.value.pval)
+    ))
 
-//  val gecko = ObjectType("Gecko",
-//    "",
-//    fields[Backend, Gecko](
-//      Field("genes", ListType(gene),
-//        Some(""),
-//        resolve = rsl => genesFetcher.deferSeq(rsl.value.geneIds)),
-//      Field("tagVariants", ListType(variant),
-//        Some(""),
-//        resolve = _.value.tagVariants),
-//      Field("indexVariants", ListType(variant),
-//        Some(""),
-//        resolve = _.value.indexVariants),
-//      Field("studies", ListType(study),
-//        Some(""),
-//        resolve = rsl => studiesFetcher.deferSeq(rsl.value.studies)),
-//      Field("geneTagVariants", ListType(geneTagVariant),
-//        Some(""),
-//        resolve = _.value.geneTagVariants),
-//      Field("tagVariantIndexVariantStudies", ListType(tagVariantIndexVariantStudy),
-//        Some(""),
-//        resolve = _.value.tagVariantIndexVariantStudies)
-//    ))
+  val gecko = ObjectType("Gecko",
+    "",
+    fields[Backend, Gecko](
+      Field("genes", ListType(gene),
+        Some(""),
+        resolve = rsl => genesFetcher.deferSeq(rsl.value.geneIds)),
+      Field("tagVariants", ListType(variant),
+        Some(""),
+        resolve = _.value.tagVariants),
+      Field("indexVariants", ListType(variant),
+        Some(""),
+        resolve = _.value.indexVariants),
+      Field("studies", ListType(study),
+        Some(""),
+        resolve = rsl => studiesFetcher.deferSeq(rsl.value.studies)),
+      Field("geneTagVariants", ListType(geneTagVariant),
+        Some(""),
+        resolve = _.value.geneTagVariants),
+      Field("tagVariantIndexVariantStudies", ListType(tagVariantIndexVariantStudy),
+        Some(""),
+        resolve = _.value.tagVariantIndexVariantStudies)
+    ))
 
-//  val overlap = ObjectType("Overlap",
-//  "This element represent an overlap between two variants for two studies",
-//    fields[Backend, OverlappedVariant](
-//      Field("variantIdA", StringType, None, resolve = _.value.variantIdA),
-//      Field("variantIdB", StringType, None, resolve = _.value.variantIdB),
-//      Field("overlapAB", IntType, None, resolve = _.value.overlapAB),
-//      Field("distinctA", IntType, None, resolve = _.value.distinctA),
-//      Field("distinctB", IntType, None, resolve = _.value.distinctB),
-//    ))
+  val overlap = ObjectType("Overlap",
+  "This element represent an overlap between two variants for two studies",
+    fields[Backend, OverlappedVariant](
+      Field("variantIdA", StringType, None, resolve = _.value.variantIdA),
+      Field("variantIdB", StringType, None, resolve = _.value.variantIdB),
+      Field("overlapAB", IntType, None, resolve = _.value.overlapAB),
+      Field("distinctA", IntType, None, resolve = _.value.distinctA),
+      Field("distinctB", IntType, None, resolve = _.value.distinctB),
+    ))
 
-//  val overlappedStudy = ObjectType("OverlappedStudy",
-//    "This element represent a overlap between two stduies",
-//    fields[Backend, OverlapRow](
-//      Field("study", study,
-//        Some("A study object"),
-//        resolve = rsl => studiesFetcher.defer(rsl.value.stid)),
-//      Field("numOverlapLoci", IntType,
-//        Some("Orig variant id which is been used for computing the " +
-//          "overlap with the referenced study"),
-//        resolve = _.value.numOverlapLoci)
-//    ))
+  val overlappedStudy = ObjectType("OverlappedStudy",
+    "This element represent a overlap between two stduies",
+    fields[Backend, OverlapRow](
+      Field("study", study,
+        Some("A study object"),
+        resolve = rsl => studiesFetcher.defer(rsl.value.stid)),
+      Field("numOverlapLoci", IntType,
+        Some("Orig variant id which is been used for computing the " +
+          "overlap with the referenced study"),
+        resolve = _.value.numOverlapLoci)
+    ))
 
-//  val overlappedVariantsStudies = ObjectType("OverlappedVariantsStudies",
-//    "This element represent a overlap between two stduies",
-//    fields[Backend, OverlappedVariantsStudy](
-//      Field("study", OptionType(study),
-//        Some("A study object"),
-//        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
-//      Field("overlaps", ListType(overlap),
-//        Some("Orig variant id which is been used for computing the " +
-//          "overlap with the referenced study"),
-//        resolve = _.value.overlaps)
-//    ))
+  val overlappedVariantsStudies = ObjectType("OverlappedVariantsStudies",
+    "This element represent a overlap between two stduies",
+    fields[Backend, OverlappedVariantsStudy](
+      Field("study", OptionType(study),
+        Some("A study object"),
+        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
+      Field("overlaps", ListType(overlap),
+        Some("Orig variant id which is been used for computing the " +
+          "overlap with the referenced study"),
+        resolve = _.value.overlaps)
+    ))
 
-//  val topOverlappedStudies = ObjectType("TopOverlappedStudies",
-//    "This element represent a overlap between two stduies",
-//    fields[Backend, OverlappedLociStudy](
-//      Field("study", OptionType(study),
-//        Some("A study object"),
-//        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
-//      Field("topStudiesByLociOverlap", ListType(overlappedStudy),
-//        Some("Top N studies ordered by loci overlap"),
-//        resolve = _.value.topOverlappedStudies)
-//    ))
+  val topOverlappedStudies = ObjectType("TopOverlappedStudies",
+    "This element represent a overlap between two stduies",
+    fields[Backend, OverlappedLociStudy](
+      Field("study", OptionType(study),
+        Some("A study object"),
+        resolve = rsl => studiesFetcher.deferOpt(rsl.value.studyId)),
+      Field("topStudiesByLociOverlap", ListType(overlappedStudy),
+        Some("Top N studies ordered by loci overlap"),
+        resolve = _.value.topOverlappedStudies)
+    ))
 
-//  val studyForGene = ObjectType("StudyForGene", "",
-//    fields[Backend, String](
-//      Field("study", study,
-//        Some("A study object"),
-//        resolve = rsl => studiesFetcher.defer(rsl.value))
-//    ))
+  val studyForGene = ObjectType("StudyForGene", "",
+    fields[Backend, String](
+      Field("study", study,
+        Some("A study object"),
+        resolve = rsl => studiesFetcher.defer(rsl.value))
+    ))
 
-//  val overlappedInfoForStudy = ObjectType("OverlappedInfoForStudy", "",
-//    fields[Backend, (String, Seq[String])](
-//      Field("study", OptionType(study),
-//        Some("A study object"),
-//        resolve = rsl => studiesFetcher.deferOpt(rsl.value._1)),
-//      Field("overlappedVariantsForStudies", ListType(overlappedVariantsStudies),
-//        Some(""),
-//        resolve = rsl => rsl.ctx.getOverlapVariantsForStudies(rsl.value._1, rsl.value._2)),
-//      Field("variantIntersectionSet", ListType(StringType),
-//        Some(""),
-//        resolve = rsl => rsl.ctx.getOverlapVariantsIntersectionForStudies(rsl.value._1, rsl.value._2))
-//    ))
+  val overlappedInfoForStudy = ObjectType("OverlappedInfoForStudy", "",
+    fields[Backend, (String, Seq[String])](
+      Field("study", OptionType(study),
+        Some("A study object"),
+        resolve = rsl => studiesFetcher.deferOpt(rsl.value._1)),
+      Field("overlappedVariantsForStudies", ListType(overlappedVariantsStudies),
+        Some(""),
+        resolve = rsl => rsl.ctx.getOverlapVariantsForStudies(rsl.value._1, rsl.value._2)),
+      Field("variantIntersectionSet", ListType(StringType),
+        Some(""),
+        resolve = rsl => rsl.ctx.getOverlapVariantsIntersectionForStudies(rsl.value._1, rsl.value._2))
+    ))
 
-//  val manhattan = ObjectType("Manhattan",
-//    "This element represents a Manhattan like plot",
-//    fields[Backend, ManhattanTable](
-//      Field("associations", ListType(manhattanAssociation),
-//        Some("A list of associations"),
-//        resolve = _.value.associations),
-//      Field("topOverlappedStudies", OptionType(topOverlappedStudies),
-//        Some("A list of overlapped studies"),
-//        arguments = pageIndex :: pageSize :: Nil,
-//        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.value.studyId, ctx.arg(pageIndex), ctx.arg(pageSize)))
-//    ))
+  val manhattan = ObjectType("Manhattan",
+    "This element represents a Manhattan like plot",
+    fields[Backend, ManhattanTable](
+      Field("associations", ListType(manhattanAssociation),
+        Some("A list of associations"),
+        resolve = _.value.associations),
+      Field("topOverlappedStudies", OptionType(topOverlappedStudies),
+        Some("A list of overlapped studies"),
+        arguments = pageIndex :: pageSize :: Nil,
+        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.value.studyId, ctx.arg(pageIndex), ctx.arg(pageSize)))
+    ))
 
-//  val pheWAS = ObjectType("PheWAS",
-//    "This element represents a PheWAS like plot",
-//    fields[Backend, PheWASTable](
-//      Field("associations", ListType(pheWASAssociation),
-//        Some("A list of associations"),
-//        resolve = _.value.associations)
-//    ))
-
+  val pheWAS = ObjectType("PheWAS",
+    "This element represents a PheWAS like plot",
+    fields[Backend, PheWASTable](
+      Field("associations", ListType(pheWASAssociation),
+        Some("A list of associations"),
+        resolve = _.value.associations)
+    ))
 
   val tagVariantsAndStudiesForIndexVariant = ObjectType("TagVariantsAndStudiesForIndexVariant",
     "A list of rows with each link",
@@ -644,61 +643,61 @@ object GQLSchema {
         resolve = _.value.fpreds)
     ))
 
-//  val variantSearchResult = ObjectType("VariantSearchResult",
-//    "Variant search result object",
-//    fields[Backend, VariantSearchResult](
-//      Field("variant", variant,
-//        Some("A variant"),
-//        resolve = _.value.variant)
-//    ))
+  val variantSearchResult = ObjectType("VariantSearchResult",
+    "Variant search result object",
+    fields[Backend, VariantSearchResult](
+      Field("variant", variant,
+        Some("A variant"),
+        resolve = _.value.variant)
+    ))
 
-//  val searchResult = ObjectType("SearchResult",
-//    "Search data by a query string",
-//    fields[Backend, SearchResultSet](
-//      Field("totalGenes", LongType,
-//        Some("Total number of genes found"),
-//        resolve = _.value.totalGenes),
-//      Field("totalVariants", LongType,
-//        Some("Total number of variants found"),
-//        resolve = _.value.totalVariants),
-//      Field("totalStudies", LongType,
-//        Some("Total number of studies found"),
-//        resolve = _.value.totalStudies),
-//      Field("genes", ListType(gene),
-//        Some("Gene search result list"),
-//        resolve = _.value.genes),
-//      Field("variants", ListType(variantSearchResult),
-//        Some("Variant search result list"),
-//        resolve = _.value.variants),
-//      Field("studies", ListType(study),
-//        Some("Study search result list"),
-//        resolve = _.value.studies)
-//    ))
+  val searchResult = ObjectType("SearchResult",
+    "Search data by a query string",
+    fields[Backend, SearchResultSet](
+      Field("totalGenes", LongType,
+        Some("Total number of genes found"),
+        resolve = _.value.totalGenes),
+      Field("totalVariants", LongType,
+        Some("Total number of variants found"),
+        resolve = _.value.totalVariants),
+      Field("totalStudies", LongType,
+        Some("Total number of studies found"),
+        resolve = _.value.totalStudies),
+      Field("genes", ListType(gene),
+        Some("Gene search result list"),
+        resolve = _.value.genes),
+      Field("variants", ListType(variantSearchResult),
+        Some("Variant search result list"),
+        resolve = _.value.variants),
+      Field("studies", ListType(study),
+        Some("Study search result list"),
+        resolve = _.value.studies)
+    ))
 
   val query = ObjectType(
     "Query", fields[Backend, Unit](
-//      Field("search", searchResult,
-//        arguments = queryString :: pageIndex :: pageSize :: Nil,
-//        resolve = ctx =>
-//          ctx.ctx.getSearchResultSet(ctx.arg(queryString), ctx.arg(pageIndex), ctx.arg(pageSize))),
+      Field("search", searchResult,
+        arguments = queryString :: pageIndex :: pageSize :: Nil,
+        resolve = ctx =>
+          ctx.ctx.getSearchResultSet(ctx.arg(queryString), ctx.arg(pageIndex), ctx.arg(pageSize))),
       Field("studyInfo", OptionType(study),
         arguments = studyId :: Nil,
         resolve = ctx => studiesFetcher.deferOpt(ctx.arg(studyId))),
       Field("variantInfo", OptionType(variant),
         arguments = variantId :: Nil,
         resolve = ctx => variantsFetcher.deferOpt(ctx.arg(variantId))),
-//      Field("studiesForGene", ListType(studyForGene),
-//        arguments = geneId :: Nil,
-//        resolve = ctx => ctx.ctx.getStudiesForGene(ctx.arg(geneId))),
-//      Field("manhattan", manhattan,
-//        arguments = studyId :: pageIndex :: pageSize :: Nil,
-//        resolve = ctx => ctx.ctx.buildManhattanTable(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-//      Field("topOverlappedStudies", topOverlappedStudies,
-//        arguments = studyId :: pageIndex :: pageSize :: Nil,
-//        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-//      Field("overlapInfoForStudy", overlappedInfoForStudy,
-//        arguments = studyId :: studyIds :: Nil,
-//        resolve = ctx => (ctx.arg(studyId),  ctx.arg(studyIds))),
+      Field("studiesForGene", ListType(studyForGene),
+        arguments = geneId :: Nil,
+        resolve = ctx => ctx.ctx.getStudiesForGene(ctx.arg(geneId))),
+      Field("manhattan", manhattan,
+        arguments = studyId :: pageIndex :: pageSize :: Nil,
+        resolve = ctx => ctx.ctx.buildManhattanTable(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+      Field("topOverlappedStudies", topOverlappedStudies,
+        arguments = studyId :: pageIndex :: pageSize :: Nil,
+        resolve = ctx => ctx.ctx.getTopOverlappedStudies(ctx.arg(studyId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+      Field("overlapInfoForStudy", overlappedInfoForStudy,
+        arguments = studyId :: studyIds :: Nil,
+        resolve = ctx => (ctx.arg(studyId),  ctx.arg(studyIds))),
       Field("tagVariantsAndStudiesForIndexVariant", tagVariantsAndStudiesForIndexVariant,
         arguments = variantId :: pageIndex :: pageSize :: Nil,
         resolve = ctx =>
@@ -707,12 +706,12 @@ object GQLSchema {
         arguments = variantId :: pageIndex :: pageSize :: Nil,
         resolve = ctx =>
           ctx.ctx.buildTagVariantAssocTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-//      Field("pheWAS", pheWAS,
-//        arguments = variantId :: pageIndex :: pageSize :: Nil,
-//        resolve = ctx => ctx.ctx.buildPheWASTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
-//      Field("gecko", OptionType(gecko),
-//        arguments = chromosome :: dnaPosStart :: dnaPosEnd :: Nil,
-//        resolve = ctx => ctx.ctx.buildGecko(ctx.arg(chromosome), ctx.arg(dnaPosStart), ctx.arg(dnaPosEnd))),
+      Field("pheWAS", pheWAS,
+        arguments = variantId :: pageIndex :: pageSize :: Nil,
+        resolve = ctx => ctx.ctx.buildPheWASTable(ctx.arg(variantId), ctx.arg(pageIndex), ctx.arg(pageSize))),
+      Field("gecko", OptionType(gecko),
+        arguments = chromosome :: dnaPosStart :: dnaPosEnd :: Nil,
+        resolve = ctx => ctx.ctx.buildGecko(ctx.arg(chromosome), ctx.arg(dnaPosStart), ctx.arg(dnaPosEnd))),
       Field("genesForVariantSchema", v2gSchema,
         arguments = Nil,
         resolve = ctx => ctx.ctx.getG2VSchema),

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -716,9 +716,9 @@ object GQLSchema {
       Field("genesForVariant", ListType(geneForVariant),
         arguments = variantId :: Nil,
         resolve = ctx => ctx.ctx.buildG2VByVariant(ctx.arg(variantId))),
-      Field("variantsForGene", ListType(geneForVariant),
-        arguments = geneId :: Nil,
-        resolve = ctx => ctx.ctx.buildG2VByGene(ctx.arg(geneId)))
+//      Field("variantsForGene", ListType(geneForVariant),
+//        arguments = geneId :: Nil,
+//        resolve = ctx => ctx.ctx.buildG2VByGene(ctx.arg(geneId)))
     ))
 
   val schema = Schema(query)

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -525,125 +525,124 @@ object GQLSchema {
         resolve = _.value.functionalPredictions)
     ))
 
-//  val qtlTissue = ObjectType("QTLTissue",
-//    "",
-//    fields[Backend, QTLTissue](
-//      Field("tissue", tissue,
-//        Some(""),
-//        resolve = _.value.tissue),
-//      Field("quantile", FloatType,
-//        Some(""),
-//        resolve = _.value.quantile),
-//      Field("beta", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.beta),
-//      Field("pval", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.pval)
-//    ))
-//
-//  val intervalTissue = ObjectType("IntervalTissue",
-//    "",
-//    fields[Backend, IntervalTissue](
-//      Field("tissue", tissue,
-//        Some(""),
-//        resolve = _.value.tissue),
-//      Field("quantile", FloatType,
-//        Some(""),
-//        resolve = _.value.quantile),
-//      Field("score", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.score)
-//    ))
-//
-//  val fpredTissue = ObjectType("FPredTissue",
-//    "",
-//    fields[Backend, FPredTissue](
-//      Field("tissue", tissue,
-//        Some(""),
-//        resolve = _.value.tissue),
-//      Field("maxEffectLabel", OptionType(StringType),
-//        Some(""),
-//        resolve = _.value.maxEffectLabel),
-//      Field("maxEffectScore", OptionType(FloatType),
-//        Some(""),
-//        resolve = _.value.maxEffectScore)
-//    ))
+  val qtlTissue = ObjectType("QTLTissue",
+    "",
+    fields[Backend, QTLTissue](
+      Field("tissue", tissue,
+        Some(""),
+        resolve = _.value.tissue),
+      Field("quantile", FloatType,
+        Some(""),
+        resolve = _.value.quantile),
+      Field("beta", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.beta),
+      Field("pval", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.pval)
+    ))
 
+  val intervalTissue = ObjectType("IntervalTissue",
+    "",
+    fields[Backend, IntervalTissue](
+      Field("tissue", tissue,
+        Some(""),
+        resolve = _.value.tissue),
+      Field("quantile", FloatType,
+        Some(""),
+        resolve = _.value.quantile),
+      Field("score", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.score)
+    ))
 
-//  val qtlElement = ObjectType("QTLElement",
-//    "A list of rows with each link",
-//    fields[Backend, G2VElement[QTLTissue]](
-//      Field("typeId", StringType,
-//        Some(""),
-//        resolve = _.value.id),
-//      Field("sourceId", StringType,
-//        Some(""),
-//        resolve = _.value.sourceId),
-//      Field("aggregatedScore", FloatType,
-//        Some(""),
-//        resolve = _.value.aggregatedScore),
-//      Field("tissues", ListType(qtlTissue),
-//        Some(""),
-//        resolve = _.value.tissues)
-//    ))
-//
-//  val intervalElement = ObjectType("IntervalElement",
-//    "A list of rows with each link",
-//    fields[Backend, G2VElement[IntervalTissue]](
-//      Field("typeId", StringType,
-//        Some(""),
-//        resolve = _.value.id),
-//      Field("sourceId", StringType,
-//        Some(""),
-//        resolve = _.value.sourceId),
-//      Field("aggregatedScore", FloatType,
-//        Some(""),
-//        resolve = _.value.aggregatedScore),
-//      Field("tissues", ListType(intervalTissue),
-//        Some(""),
-//        resolve = _.value.tissues)
-//    ))
-//
-//  val fPredElement = ObjectType("FunctionalPredictionElement",
-//    "A list of rows with each link",
-//    fields[Backend, G2VElement[FPredTissue]](
-//      Field("typeId", StringType,
-//        Some(""),
-//        resolve = _.value.id),
-//      Field("sourceId", StringType,
-//        Some(""),
-//        resolve = _.value.sourceId),
-//      Field("aggregatedScore", FloatType,
-//        Some(""),
-//        resolve = _.value.aggregatedScore),
-//      Field("tissues", ListType(fpredTissue),
-//        Some(""),
-//        resolve = _.value.tissues)
-//    ))
+  val fpredTissue = ObjectType("FPredTissue",
+    "",
+    fields[Backend, FPredTissue](
+      Field("tissue", tissue,
+        Some(""),
+        resolve = _.value.tissue),
+      Field("maxEffectLabel", OptionType(StringType),
+        Some(""),
+        resolve = _.value.maxEffectLabel),
+      Field("maxEffectScore", OptionType(FloatType),
+        Some(""),
+        resolve = _.value.maxEffectScore)
+    ))
 
-//  val geneForVariant = ObjectType("GeneForVariant",
-//    "A list of rows with each link",
-//    fields[Backend, G2VAssociation](
-//      Field("gene", gene,
-//        Some("Associated scored gene"),
-//        resolve = rsl => genesFetcher.defer(rsl.value.geneId)),
-//      Field("variant", StringType,
-//        Some("Associated scored variant"),
-//        resolve = _.value.variantId),
-//      Field("overallScore", FloatType,
-//        Some(""),
-//        resolve = _.value.overallScore),
-//      Field("qtls", ListType(qtlElement),
-//        Some(""),
-//        resolve = _.value.qtls),
-//      Field("intervals", ListType(intervalElement),
-//        Some(""),
-//        resolve = _.value.intervals),
-//      Field("functionalPredictions", ListType(fPredElement),
-//        Some(""),
-//        resolve = _.value.fpreds)
-//    ))
+  val qtlElement = ObjectType("QTLElement",
+    "A list of rows with each link",
+    fields[Backend, G2VElement[QTLTissue]](
+      Field("typeId", StringType,
+        Some(""),
+        resolve = _.value.id),
+      Field("sourceId", StringType,
+        Some(""),
+        resolve = _.value.sourceId),
+      Field("aggregatedScore", FloatType,
+        Some(""),
+        resolve = _.value.aggregatedScore),
+      Field("tissues", ListType(qtlTissue),
+        Some(""),
+        resolve = _.value.tissues)
+    ))
+
+  val intervalElement = ObjectType("IntervalElement",
+    "A list of rows with each link",
+    fields[Backend, G2VElement[IntervalTissue]](
+      Field("typeId", StringType,
+        Some(""),
+        resolve = _.value.id),
+      Field("sourceId", StringType,
+        Some(""),
+        resolve = _.value.sourceId),
+      Field("aggregatedScore", FloatType,
+        Some(""),
+        resolve = _.value.aggregatedScore),
+      Field("tissues", ListType(intervalTissue),
+        Some(""),
+        resolve = _.value.tissues)
+    ))
+
+  val fPredElement = ObjectType("FunctionalPredictionElement",
+    "A list of rows with each link",
+    fields[Backend, G2VElement[FPredTissue]](
+      Field("typeId", StringType,
+        Some(""),
+        resolve = _.value.id),
+      Field("sourceId", StringType,
+        Some(""),
+        resolve = _.value.sourceId),
+      Field("aggregatedScore", FloatType,
+        Some(""),
+        resolve = _.value.aggregatedScore),
+      Field("tissues", ListType(fpredTissue),
+        Some(""),
+        resolve = _.value.tissues)
+    ))
+
+  val geneForVariant = ObjectType("GeneForVariant",
+    "A list of rows with each link",
+    fields[Backend, G2VAssociation](
+      Field("gene", gene,
+        Some("Associated scored gene"),
+        resolve = rsl => genesFetcher.defer(rsl.value.geneId)),
+      Field("variant", StringType,
+        Some("Associated scored variant"),
+        resolve = _.value.variantId),
+      Field("overallScore", FloatType,
+        Some(""),
+        resolve = _.value.overallScore),
+      Field("qtls", ListType(qtlElement),
+        Some(""),
+        resolve = _.value.qtls),
+      Field("intervals", ListType(intervalElement),
+        Some(""),
+        resolve = _.value.intervals),
+      Field("functionalPredictions", ListType(fPredElement),
+        Some(""),
+        resolve = _.value.fpreds)
+    ))
 
 //  val variantSearchResult = ObjectType("VariantSearchResult",
 //    "Variant search result object",
@@ -717,9 +716,9 @@ object GQLSchema {
       Field("genesForVariantSchema", v2gSchema,
         arguments = Nil,
         resolve = ctx => ctx.ctx.getG2VSchema),
-//      Field("genesForVariant", ListType(geneForVariant),
-//        arguments = variantId :: Nil,
-//        resolve = ctx => ctx.ctx.buildG2VByVariant(ctx.arg(variantId))),
+      Field("genesForVariant", ListType(geneForVariant),
+        arguments = variantId :: Nil,
+        resolve = ctx => ctx.ctx.buildG2VByVariant(ctx.arg(variantId))),
 //      Field("variantsForGene", ListType(geneForVariant),
 //        arguments = geneId :: Nil,
 //        resolve = ctx => ctx.ctx.buildG2VByGene(ctx.arg(geneId)))

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -4,7 +4,8 @@ package models
 import sangria.execution.deferred._
 import sangria.schema._
 import Entities._
-import DNA._
+import DNA.Variant
+import FRM.Gene
 import sangria.schema
 import sangria.streaming.ValidOutStreamType
 
@@ -20,6 +21,8 @@ object GQLSchema {
   val dnaPosStart = Argument("start", LongType, description = "Start position in a specified chromosome")
   val dnaPosEnd = Argument("end", LongType, description = "End position in a specified chromosome")
   val queryString = Argument("queryString", StringType, description = "Query text to search for")
+
+  implicit val geneHasId = HasId[FRM.Gene, String](_.id)
 
   val gene = ObjectType("Gene",
   "This element represents a simple gene object which contains id and name",
@@ -48,7 +51,8 @@ object GQLSchema {
       Field("fwdStrand", OptionType(BooleanType),
         Some("Forward strand true or false"),
         resolve = _.value.fwd),
-      Field("exons", ListType(LongType),
+//      Field("exons", ListType(LongType),
+      Field("exons", OptionType(StringType),
         Some("Approved symbol name of a gene"),
         resolve = _.value.exons)
     ))

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -4,11 +4,11 @@ package models
 import sangria.execution.deferred._
 import sangria.schema._
 import Entities._
-//import DNA.Variant
-import FRM.Variant
+import DNA.Variant
+//import FRM.Variant
 import sangria.schema
 import sangria.streaming.ValidOutStreamType
-//import Entities.DBImplicits.frm2gqlVariant
+import Entities.DBImplicits.frm2dnaVariant
 
 object GQLSchema {
   val studyId = Argument("studyId", StringType, description = "Study ID which links a top loci with a trait")
@@ -74,7 +74,7 @@ object GQLSchema {
 
   val variant = ObjectType("Variant",
     "This element represents a variant object",
-    fields[Backend, Variant](
+    fields[Backend, DNA.Variant](
       Field("id", StringType,
         Some("Ensembl Gene ID of a gene"),
         resolve = _.value.id),
@@ -83,10 +83,10 @@ object GQLSchema {
         resolve = _.value.rsId),
       Field("chromosome", StringType,
         Some("Ensembl Gene ID of a gene"),
-        resolve = _.value.chromosome),
+        resolve = _.value.position.chrId),
       Field("position", LongType,
         Some("Approved symbol name of a gene"),
-        resolve = _.value.position),
+        resolve = _.value.position.position),
       Field("refAllele", StringType,
         Some("Ref allele"),
         resolve = _.value.refAllele),

--- a/test/models/DNASpec.scala
+++ b/test/models/DNASpec.scala
@@ -35,7 +35,7 @@ class DNASpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
 
   "A Variant 1_1234_C_. must equal to a Right(Variant)" in {
     val v1 = Variant("1_1234_C_.")
-    val rv1 = Right(Variant(DNA.Position("1", 1234), "C", ".", None))
+    val rv1 = Right(Variant("1", 1234, "C", ".", None))
 
     v1 mustEqual rv1
   }


### PR DESCRIPTION
This PR:
* creates slick table definitions corresponding to clickhouse tables `gene`, `variants` and `studies`
* uses the above with the slick DSL in the `getGenes`, `getVariants` and `getStudies` resolvers
* removes the query `variantsForGene(geneId)`, which is not currently in use

This is experimental. While all queries still work following the changes, there are some difficulties using slick across all current queries. Specifically, there is no obvious way to ensure joins use the `ALL` keyword. There are likely to be other instances of the DSL mapping to an unsatisfactory SQL query unless we drastically simplify the clickhouse representation.