### PR TITLE
Remove `seu` field from variant.

### DIFF
--- a/app/models/database/FRM.scala
+++ b/app/models/database/FRM.scala
@@ -119,8 +119,6 @@ object FRM {
 
     def gnomadAFR = column[Option[Double]]("gnomad_afr")
 
-    def gnomadSEU = column[Option[Double]]("gnomad_seu")
-
     def gnomadAMR = column[Option[Double]]("gnomad_amr")
 
     def gnomadASJ = column[Option[Double]]("gnomad_asj")
@@ -156,7 +154,6 @@ object FRM {
     def gnomadAnnotations =
       (
         gnomadAFR,
-        gnomadSEU,
         gnomadAMR,
         gnomadASJ,
         gnomadEAS,

--- a/app/models/entities/DNA.scala
+++ b/app/models/entities/DNA.scala
@@ -87,7 +87,6 @@ object DNA {
 
   case class GnomadAnnotation(
                                afr: Option[Double] = None,
-                               seu: Option[Double] = None,
                                amr: Option[Double] = None,
                                asj: Option[Double] = None,
                                eas: Option[Double] = None,

--- a/app/models/implicits/EsImplicits.scala
+++ b/app/models/implicits/EsImplicits.scala
@@ -46,7 +46,6 @@ object EsImplicits {
 
   implicit val gnomadAnnotation: Reads[GnomadAnnotation] = (
     (JsPath \ "gnomad_afr").readNullable[Double] and
-      (JsPath \ "gnomad_seu").readNullable[Double] and
       (JsPath \ "gnomad_amr").readNullable[Double] and
       (JsPath \ "gnomad_asj").readNullable[Double] and
       (JsPath \ "gnomad_eas").readNullable[Double] and


### PR DESCRIPTION
In the outputs from the ETL there is no column called `gnomad_seu`. This was part of the SQL load scripts but did not work with Parquet as the column was not present in the data. The field was not exposed through the API. I'm removing since that was the cause of one of the errors where the API was crashing.