### PR TITLE
Add handling of missing gene values.

### DIFF
--- a/app/models/gql/GQLSchema.scala
+++ b/app/models/gql/GQLSchema.scala
@@ -4,6 +4,7 @@ import components.Backend
 import models.entities.DNA
 import models.entities.DNA.SimpleVariant
 import models.entities.Entities._
+import play.api.Logging
 import sangria.execution.deferred.DeferredResolver
 import sangria.macros.derive._
 import sangria.schema.{
@@ -32,7 +33,8 @@ object GQLSchema
     with GQLArguments
     with GQLOverlaps
     with GQLTissue
-    with GQLMetadata {
+    with GQLMetadata
+    with Logging {
 
   val resolvers: DeferredResolver[Backend] =
     DeferredResolver.fetchers(studiesFetcher, genesFetcher, variantsFetcher)
@@ -394,7 +396,22 @@ object GQLSchema
             Some("Tag variant ID as ex. 1_12345_A_T"),
             resolve = r => variantsFetcher.defer(r.value.rVariant.id)
       ),
-      Field("gene", gene, Some("Gene"), resolve = rsl => genesFetcher.defer(rsl.value.rGeneId.get)),
+      // the field rGeneId is always null for GWAS, but should always be present for qtl data. This has proven not to
+      // hold so we want to be cautious here.
+      Field(
+        "gene",
+        gene,
+        Some("Gene"),
+        resolve = ctx =>
+          ctx.value.rGeneId match {
+            case Some(gene) => genesFetcher.defer(gene)
+            case None =>
+              logger.error(
+                s"QTL coloc for right_variant ${ctx.value.rVariant} requested with no gene ID."
+              )
+              throw new IllegalArgumentException
+          }
+      ),
       Field("phenotypeId",
             StringType,
             Some("QTL Phenotype ID"),


### PR DESCRIPTION
We would always expect that the right gene id to have a value in the case of qtls. When this isn't the case it's a data issue, and we don't want to fail silently.